### PR TITLE
use var instead of let, for more familiar semantics

### DIFF
--- a/lib/commands/connect/auth_connection.js
+++ b/lib/commands/connect/auth_connection.js
@@ -1,15 +1,15 @@
 'use strict';
-let cli = require('heroku-cli-util');
-let api = require('./shared.js');
-let open = require('open');
-let http = require('http');
-let url = require('url');
+var cli = require('heroku-cli-util');
+var api = require('./shared.js');
+var open = require('open');
+var http = require('http');
+var url = require('url');
 
 function callbackServer() {
-  let server = http.createServer(function (request, response) {
+  var server = http.createServer(function (request, response) {
     response.writeHead(200, {"Content-Type": "text/html"});
     console.log("Authorization complete");
-    let res = "<html><body><h3>Authorization complete</h3><p>You may close this window and return to the terminal to continue.</p></body></html>";
+    var res = "<html><body><h3>Authorization complete</h3><p>You may close this window and return to the terminal to continue.</p></body></html>";
     response.end(res);
     process.exit();
   });
@@ -34,13 +34,13 @@ module.exports = {
             callbackServer();
 
             try {
-              let args = {'environment':'production', 'next': 'http://127.0.0.1:18000'};
+              var args = {'environment':'production', 'next': 'http://127.0.0.1:18000'};
               if (context.flags.login) {
                 args.login_url = context.flags.login;
               }
               api.request(context.auth.password,
                 'POST', '/api/v3/connections/' + connections[0].id + '/authorize_url', args).then(function(response) {
-                  let redir = response.json.redirect;
+                  var redir = response.json.redirect;
                   console.log("Launching Salesforce for authorization. If your browser doesn't open, please copy the following URL to proceed:\n\n" + redir + "\n");
                   open(redir);
               });

--- a/lib/commands/connect/export.js
+++ b/lib/commands/connect/export.js
@@ -1,8 +1,8 @@
 'use strict';
-let api = require('./shared.js');
-let cli = require('heroku-cli-util');
-let co  = require('co');
-let fs  = require('fs');
+var api = require('./shared.js');
+var cli = require('heroku-cli-util');
+var co  = require('co');
+var fs  = require('fs');
 
 module.exports = {
     topic: 'connect',
@@ -15,10 +15,10 @@ module.exports = {
     needsApp: true,
     needsAuth: true,
     run: cli.command(co.wrap(function* (context, heroku) {
-      let connection = yield api.withConnection(context, heroku);
-      let url = '/api/v3/connections/' + connection.id + '/actions/export';
-      let response = yield api.request(context.auth.password, 'GET', url)
-      let fName = connection.app_name + "-" + (connection.resource_name || '') + ".json";
+      var connection = yield api.withConnection(context, heroku);
+      var url = '/api/v3/connections/' + connection.id + '/actions/export';
+      var response = yield api.request(context.auth.password, 'GET', url)
+      var fName = connection.app_name + "-" + (connection.resource_name || '') + ".json";
 
       fs.writeFile(fName, JSON.stringify(response.json, null, 4), function(err) {
         if(err) {

--- a/lib/commands/connect/import.js
+++ b/lib/commands/connect/import.js
@@ -1,8 +1,8 @@
 'use strict';
-let api = require('./shared.js');
-let cli = require('heroku-cli-util');
-let co  = require('co');
-let fs  = require('fs');
+var api = require('./shared.js');
+var cli = require('heroku-cli-util');
+var co  = require('co');
+var fs  = require('fs');
 
 module.exports = {
     topic: 'connect',
@@ -18,11 +18,11 @@ module.exports = {
     needsApp: true,
     needsAuth: true,
     run: cli.command(co.wrap(function* (context, heroku) {
-      let connection = yield api.withConnection(context, heroku);
-      let url = '/api/v3/connections/' + connection.id + '/actions/import';
+      var connection = yield api.withConnection(context, heroku);
+      var url = '/api/v3/connections/' + connection.id + '/actions/import';
       fs.readFile(context.args.file, 'utf8', co.wrap(function* (err, data) {
         data = JSON.parse(data);
-        let response = yield api.request(context.auth.password, 'POST', url, data);
+        var response = yield api.request(context.auth.password, 'POST', url, data);
         console.log("Upload complete");
         console.log(response.text);
       }));

--- a/lib/commands/connect/info.js
+++ b/lib/commands/connect/info.js
@@ -1,7 +1,7 @@
 'use strict';
-let api = require('./shared.js');
-let cli = require('heroku-cli-util');
-let co  = require('co');
+var api = require('./shared.js');
+var cli = require('heroku-cli-util');
+var co  = require('co');
 
 module.exports = {
     topic: 'connect',
@@ -15,7 +15,7 @@ module.exports = {
     needsApp: true,
     needsAuth: true,
     run: cli.command(co.wrap(function* (context, heroku) {
-      let connections = yield api.withUserConnections(context.auth.password, context.app, context.flags, true, heroku);
+      var connections = yield api.withUserConnections(context.auth.password, context.app, context.flags, true, heroku);
 
       if (connections.length === 0) {
         console.log("No connection found, requesting auth...");

--- a/lib/commands/connect/mapping-create.js
+++ b/lib/commands/connect/mapping-create.js
@@ -1,7 +1,7 @@
 'use strict';
 var Q = require('q');
 var api = require('./shared.js');
-let cli = require('heroku-cli-util');
+var cli = require('heroku-cli-util');
 
 module.exports = {
     topic: 'connect',

--- a/lib/commands/connect/mapping-delete.js
+++ b/lib/commands/connect/mapping-delete.js
@@ -1,7 +1,7 @@
 'use strict';
 var Q = require('q');
 var api = require('./shared.js');
-let cli = require('heroku-cli-util');
+var cli = require('heroku-cli-util');
 
 module.exports = {
     topic: 'connect',

--- a/lib/commands/connect/pause.js
+++ b/lib/commands/connect/pause.js
@@ -1,6 +1,6 @@
 'use strict';
 var api = require('./shared.js');
-let cli = require('heroku-cli-util');
+var cli = require('heroku-cli-util');
 
 module.exports = {
     topic: 'connect',

--- a/lib/commands/connect/preauth.js
+++ b/lib/commands/connect/preauth.js
@@ -1,16 +1,16 @@
 'use strict';
-let cli = require('heroku-cli-util');
-let api = require('./shared.js');
-let open = require('open');
-let http = require('http');
-let url = require('url');
+var cli = require('heroku-cli-util');
+var api = require('./shared.js');
+var open = require('open');
+var http = require('http');
+var url = require('url');
 
 function callbackServer() {
-  let server = http.createServer(function (request, response) {
-    let params = url.parse(request.url, true).query;
+  var server = http.createServer(function (request, response) {
+    var params = url.parse(request.url, true).query;
     response.writeHead(200, {"Content-Type": "text/html"});
     console.log("Preauth token: ", params.token);
-    let res = "<html><body><h3>Token received: " + params.token + "</h3></body></html>";
+    var res = "<html><body><h3>Token received: " + params.token + "</h3></body></html>";
     response.end(res);
     process.exit();
   });
@@ -31,7 +31,7 @@ module.exports = {
     run: function (context) {
       callbackServer();
       try {
-        let args = {'next': 'http://127.0.0.1:18000'};
+        var args = {'next': 'http://127.0.0.1:18000'};
         if (context.flags.login) {
           args.login_url = context.flags.login;
         }

--- a/lib/commands/connect/restart.js
+++ b/lib/commands/connect/restart.js
@@ -1,6 +1,6 @@
 'use strict';
 var api = require('./shared.js');
-let cli = require('heroku-cli-util');
+var cli = require('heroku-cli-util');
 
 module.exports = {
     topic: 'connect',

--- a/lib/commands/connect/resume.js
+++ b/lib/commands/connect/resume.js
@@ -1,6 +1,6 @@
 'use strict';
 var api = require('./shared.js');
-let cli = require('heroku-cli-util');
+var cli = require('heroku-cli-util');
 
 module.exports = {
     topic: 'connect',

--- a/lib/commands/connect/setup.js
+++ b/lib/commands/connect/setup.js
@@ -1,5 +1,5 @@
 'use strict';
-let cli = require('heroku-cli-util');
+var cli = require('heroku-cli-util');
 var api = require('./shared.js');
 
 function connection_info(conn) {
@@ -23,10 +23,10 @@ module.exports = {
     needsApp: true,
     needsAuth: true,
     run: cli.command(function (context, heroku) {
-      let schema = context.flags.schema || 'salesforce';
-      let db = context.flags.db || 'DATABASE_URL';
+      var schema = context.flags.schema || 'salesforce';
+      var db = context.flags.db || 'DATABASE_URL';
 
-      let data = {schema_name:schema, db_key:db};
+      var data = {schema_name:schema, db_key:db};
       if (context.flags.token) {
         data.preauth_token = context.flags.token;
       }

--- a/lib/commands/connect/state.js
+++ b/lib/commands/connect/state.js
@@ -1,6 +1,6 @@
 'use strict';
-let api = require('./shared.js');
-let co  = require('co');
+var api = require('./shared.js');
+var co  = require('co');
 
 module.exports = {
     topic: 'connect',
@@ -13,7 +13,7 @@ module.exports = {
     needsApp: true,
     needsAuth: true,
     run: co.wrap(function* (context) {
-      let connections = yield api.withUserConnections(context.auth.password, context.app, context.flags);
+      var connections = yield api.withUserConnections(context.auth.password, context.app, context.flags);
       connections.forEach(function(connection) {
         console.log(connection.state);
       });


### PR DESCRIPTION
Functionality, none of these places exhibit different behavior between `var` and `let`, but it's better to be in a habit of using semantics that are more familiar to us, either from a Python background or a more traditional JavaScript background. `let` is geared more toward a C++/Java background, and is likely to get us into trouble if we're not particularly careful with it.