### PR TITLE
Remove -r flags, which conflict with --remote

### DIFF
--- a/lib/commands/connect/export.js
+++ b/lib/commands/connect/export.js
@@ -10,7 +10,7 @@ module.exports = {
     description: 'Export configuration from a connection',
     help: 'Exports the mapping configuration from a connection as a json file',
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/import.js
+++ b/lib/commands/connect/import.js
@@ -13,7 +13,7 @@ module.exports = {
       {name: 'file', desciption: 'JSON export file name'}
     ],
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/info.js
+++ b/lib/commands/connect/info.js
@@ -10,7 +10,7 @@ module.exports = {
     description: 'display connection information',
     help: 'display connection information',
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/mapping-create.js
+++ b/lib/commands/connect/mapping-create.js
@@ -17,7 +17,6 @@ module.exports = {
     flags: [
       {
         name: 'resource', 
-        char: 'r', 
         description: 'specific connection resource name', 
         hasValue: true
       },

--- a/lib/commands/connect/mapping-delete.js
+++ b/lib/commands/connect/mapping-delete.js
@@ -16,7 +16,7 @@ module.exports = {
     ],
 
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/mapping-state.js
+++ b/lib/commands/connect/mapping-state.js
@@ -10,7 +10,7 @@ module.exports = {
   help: 'return a mapping state',
   args: [ {name: 'mapping'}],
   flags: [
-    {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+    {name: 'resource', description: 'specific connection resource name', hasValue: true}
   ],
   needsApp: true,
   needsAuth: true,

--- a/lib/commands/connect/pause.js
+++ b/lib/commands/connect/pause.js
@@ -9,7 +9,7 @@ module.exports = {
     description: 'Pause a connection',
     help: 'Pauses an active connection',
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/restart.js
+++ b/lib/commands/connect/restart.js
@@ -8,7 +8,7 @@ module.exports = {
     description: 'Restart a connection',
     help: 'Clears errors and attempts to resume sync operations',
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/resume.js
+++ b/lib/commands/connect/resume.js
@@ -9,7 +9,7 @@ module.exports = {
     description: 'Resume a connection',
     help: 'Resumes a paused connection',
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,

--- a/lib/commands/connect/setup.js
+++ b/lib/commands/connect/setup.js
@@ -15,7 +15,7 @@ module.exports = {
     description: 'configure a new connection',
     help: 'Configure a connection with db key and SF auth',
     flags: [
-       {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true},
+       {name: 'resource', description: 'specific connection resource name', hasValue: true},
        {name: 'db', char: 'd', description: 'database config var name', hasValue: true},
        {name: 'schema', char: 's', description: 'database schema name', hasValue: true},
        {name: 'token', char: 't', description: 'SF preauth token', hasValue: true}

--- a/lib/commands/connect/state.js
+++ b/lib/commands/connect/state.js
@@ -9,7 +9,7 @@ module.exports = {
     description: 'return the connection(s) state',
     help: 'returns the state key of the selected connections',
     flags: [
-      {name: 'resource', char: 'r', description: 'specific connection resource name', hasValue: true}
+      {name: 'resource', description: 'specific connection resource name', hasValue: true}
     ],
     needsApp: true,
     needsAuth: true,


### PR DESCRIPTION
I believe we added this before the toolbelt added its own `--remote`/`-r` flag. We can still use `--resource`, but competing usage of `-r` is a bad idea.