### PR TITLE
Remove Q as a dependency

### DIFF
--- a/lib/commands/connect/shared.js
+++ b/lib/commands/connect/shared.js
@@ -5,7 +5,6 @@ let fs = require('fs');
 let path = require('path');
 let https = require('https');
 let querystring = require('querystring');
-let Q = require('q');
 let Heroku = require('heroku-client');
 
 let US_HOST = 'connect.heroku.com';
@@ -61,7 +60,7 @@ let request = exports.request = function(token, method, path, data){
 
   //console.log(method, exports.HOST, path);
 
-  let promise = Q.Promise(function(resolve, reject) {
+  let promise = new Promise(function(resolve, reject) {
     let req = https.request({
       hostname: exports.HOST,
       port: PORT,
@@ -171,17 +170,21 @@ exports.withConnection = function(context, heroku) {
 }
 
 let withMapping = exports.withMapping = function(connection, object_name) {
-  return Q.Promise(function(resolve, reject) {
+  return co(function* () {
     let object_name_lower = object_name.toLowerCase();
-    connection.mappings.forEach(function(mapping) {
-      if (mapping.object_name.toLowerCase().indexOf(object_name_lower) == 0) {
-        return resolve(mapping);
+    let mapping = undefined;
+    connection.mappings.forEach(function (m) {
+      if (m.object_name.toLowerCase().indexOf(object_name_lower) == 0) {
+        mapping = m;
       }
     });
-
-    reject('No mapping configured for ' + object_name);
-  })
-}
+    if (mapping != undefined) {
+      return yield Promise.resolve(mapping);
+    } else {
+      throw new Error('No mapping configured for ' + object_name);
+    }
+  });
+};
 
 // USED by create-mapping
 exports.withRequiredFields = function(token, connectionId, objectName){
@@ -199,17 +202,14 @@ exports.withRequiredFields = function(token, connectionId, objectName){
   });
 };
 
-exports.requestAppAccess = function(token, app) {
+exports.requestAppAccess = co.wrap(function* (token, app) {
   global_config();
 
   let url = '/api/v3/users/me/apps/' + app + '/auth';
   console.log("POST ", url);
-  return request(token, 'POST', url).then(function(response){
-      return Q.Promise(function(resolve, reject){
-        resolve(response.json);
-      });
-  });
-}
+  let response = yield request(token, 'POST', url);
+  return yield Promise.resolve(response.json);
+});
 
 exports.connection_string = function(conn) {
   return 'Connection [' + conn.id + ' / ' + conn.resource_name + ']';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,5 @@
     "heroku-cli-util": "^5.4.6",
     "heroku-client": "^1.10.0",
     "open": "0.0.5",
-    "q": "^1.3.0"
   }
 }


### PR DESCRIPTION
`co` does a better job at promises, and happens to be the recommended best practice from the Heroku Toolbelt plugin development docs.