### PR TITLE
Fix scope for the addon variable

### DIFF
--- a/lib/commands/connect/shared.js
+++ b/lib/commands/connect/shared.js
@@ -116,8 +116,9 @@ let withUserConnections = exports.withUserConnections = co.wrap(function* (token
     console.log("Calling Platform API for resource id");
 
     return co(function* () {
+      let addon;
       try {
-        let addon = yield heroku.apps(appName).addons(flags.resource).info();
+        addon = yield heroku.apps(appName).addons(flags.resource).info();
       } catch(err) {
         if (err.statusCode === 404) {
           err.body.message = "Connection with resource name '" + flags.resource + "' not found";


### PR DESCRIPTION
“let” isn’t as forgiving as “var”, so this didn’t work right. Now it does.