### PR TITLE
Add a repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "description": "Heroku Connect plugin for Heroku Toolbelt",
   "version": "0.3.2",
   "author": "Heroku (@heroku)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/heroku/heroku-connect-plugin.git"
+  },
   "bugs": {
     "url": "https://github.com/heroku/heroku-connect-plugin/issues"
   },


### PR DESCRIPTION
This is probably nice to have anyway, but in particular npm kept issuing warnings because it wasn't present. Now those warnings can go away.