### PR TITLE
Update to connect-us.heroku.com

### DIFF
--- a/lib/commands/connect/shared.js
+++ b/lib/commands/connect/shared.js
@@ -7,7 +7,7 @@ let https = require('https');
 let querystring = require('querystring');
 let Heroku = require('heroku-client');
 
-let US_HOST = 'connect.heroku.com';
+let US_HOST = 'connect-us.heroku.com';
 let EU_HOST = 'connect-eu.heroku.com';
 if (process.env['CONNECT_ADDON'] == 'connectqa') {
   US_HOST = 'dev-herokuconnect.herokuapp.com';


### PR DESCRIPTION
Win one for centralized libraries! Also, I don't know if we'll need to add a `dev-herokuconnect-us.herokuapp.com` at some point as well, but it doesn't exist today, so we can revisit later if/when we decide to go that route.