### PR TITLE
Hot-fix for production-eu tests

### DIFF
--- a/lib/commands/connect/shared.js
+++ b/lib/commands/connect/shared.js
@@ -30,7 +30,12 @@ let global_config = exports.global_config = function(context) {
 }
 
 let save_eu_apps = function() {
-  fs.writeFile(path.join(process.env.HOME, '.heroku', 'connect'), JSON.stringify(eu_apps), 'utf8');
+  let herokuPath = path.join(process.env.HOME, '.heroku')
+  // Ensure $HOME/.heroku exists before trying to create a cache file inside
+  // of it
+  fs.mkdirSync(herokuPath)
+  let connectPath = path.join(herokuPath, 'connect')
+  fs.writeFile(connectPath, JSON.stringify(eu_apps), 'utf8');
 }
 
 exports.HOST = US_HOST;


### PR DESCRIPTION
When trying to do connection:info in our testing, the tests fail because
$HOME/.heroku does not exist. This is a temporary workaround for that
issue.