### PR TITLE
Automatically detect region via the app

### DIFF
--- a/commands/connect/db-set.js
+++ b/commands/connect/db-set.js
@@ -32,7 +32,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let data = {
       db_key: context.flags.db,
       schema_name: context.flags.schema

--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -38,7 +38,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let connection = yield api.withConnection(context, heroku)
     let results = yield cli.action('Diagnosing connection', co(function * () {
       let url = '/api/v3/connections/' + connection.id + '/validations'

--- a/commands/connect/export.js
+++ b/commands/connect/export.js
@@ -17,7 +17,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let connection, response
 
     yield cli.action('fetching configuration', co(function * () {

--- a/commands/connect/import.js
+++ b/commands/connect/import.js
@@ -20,7 +20,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let fName = context.args.file
     yield cli.action(`uploading ${fName}`, co(function * () {
       let connection = yield api.withConnection(context, heroku)

--- a/commands/connect/info.js
+++ b/commands/connect/info.js
@@ -17,7 +17,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let connections = yield api.withUserConnections(context, context.app, context.flags, true, heroku)
 
     if (connections.length === 0) {

--- a/commands/connect/mapping-delete.js
+++ b/commands/connect/mapping-delete.js
@@ -20,7 +20,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     yield cli.confirmApp(context.app, context.flags.confirm)
 
     yield cli.action('deleting mapping', co(function * () {

--- a/commands/connect/mapping-diagnose.js
+++ b/commands/connect/mapping-diagnose.js
@@ -20,7 +20,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let connection = yield api.withConnection(context, heroku)
     let mapping = yield api.withMapping(connection, context.args.mapping)
     let results = yield cli.action('Diagnosing mapping', co(function * () {

--- a/commands/connect/mapping-reload.js
+++ b/commands/connect/mapping-reload.js
@@ -19,7 +19,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     yield cli.action(`initiating reload of ${context.args.mapping}`, co(function * () {
       let connection = yield api.withConnection(context, heroku)
       let mapping = yield api.withMapping(connection, context.args.mapping)

--- a/commands/connect/mapping-state.js
+++ b/commands/connect/mapping-state.js
@@ -19,7 +19,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     let connection = yield api.withConnection(context, heroku)
     let mapping = yield api.withMapping(connection, context.args.mapping)
 

--- a/commands/connect/pause.js
+++ b/commands/connect/pause.js
@@ -16,7 +16,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     yield cli.action('pausing connection', co(function * () {
       let connection = yield api.withConnection(context, heroku)
       let url = '/api/v3/connections/' + connection.id + '/actions/pause'

--- a/commands/connect/restart.js
+++ b/commands/connect/restart.js
@@ -16,7 +16,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     yield cli.action('restarting connection', co(function * () {
       let connection = yield api.withConnection(context, heroku)
       let url = '/api/v3/connections/' + connection.id + '/actions/restart'

--- a/commands/connect/resume.js
+++ b/commands/connect/resume.js
@@ -16,7 +16,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    context.region = regions.determineRegion(context)
+    context.region = yield regions.determineRegion(context, heroku)
     cli.action('resuming connection', co(function * () {
       let connection = yield api.withConnection(context, heroku)
       let url = '/api/v3/connections/' + connection.id + '/actions/resume'

--- a/commands/connect/sf-auth.js
+++ b/commands/connect/sf-auth.js
@@ -27,7 +27,7 @@ function callbackServer () {
 }
 
 function * run (context, heroku) {
-  context.region = regions.determineRegion(context)
+  context.region = yield regions.determineRegion(context, heroku)
   let redir
 
   yield cli.action('fetching authorizing URL', co(function * () {

--- a/commands/connect/state.js
+++ b/commands/connect/state.js
@@ -5,7 +5,7 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 
 function * run (context, heroku) {
-  context.region = regions.determineRegion(context)
+  context.region = yield regions.determineRegion(context, heroku)
   let connections = yield api.withUserConnections(context, context.app, context.flags, heroku)
 
   connections.forEach(function (connection) {

--- a/lib/connect/regions.js
+++ b/lib/connect/regions.js
@@ -1,5 +1,6 @@
 'use strict'
 const cli = require('heroku-cli-util')
+const co = require('co')
 
 const prodRegions = ['us', 'eu', 'tokyo', 'virginia', 'oregon', 'frankfurt', 'sydney']
 const prodRegionsMap = {}
@@ -21,25 +22,20 @@ exports.flag = {
   hasValue: true
 }
 
-let determineRegion = exports.determineRegion = function (context) {
-  let connectRegion
-  let appRegion = context.app.region
-  if (!(prodRegions.includes(appRegion) || context.flags.region)) {
-    cli.exit(1, `Please specify a --region in which you're using Heroku Connect.
-Valid regions: ${prodRegions.join(', ')}`)
-  }
+let determineRegion = exports.determineRegion = co.wrap(function * (context, heroku) {
+  let appRegion
 
   // The --region flag should override the region set on the App.
   if (context.flags.region) {
-    if (!prodRegions.includes(context.flags.region)) {
-      cli.exit(1, `Expected --region to be one of: ${prodRegions.join(', ')}`)
-    }
-    connectRegion = context.flags.region
-  } else if (prodRegions.includes(appRegion)) {
-    connectRegion = appRegion
+    appRegion = context.flags.region
+  } else {
+    appRegion = (yield heroku.apps(context.app).info()).region.name
   }
-  return connectRegion
-}
+  if (!prodRegions.includes(appRegion)) {
+    throw new Error(`Unknown region '${appRegion}'. Supported regions: ${prodRegions.join(', ')}`)
+  }
+  return appRegion
+})
 
 exports.urlFromRegion = regionName => prodRegionsMap[regionName]
 

--- a/lib/connect/regions.js
+++ b/lib/connect/regions.js
@@ -1,7 +1,7 @@
 'use strict'
 const co = require('co')
 
-const prodRegions = ['us', 'eu', 'tokyo', 'virginia', 'oregon', 'frankfurt', 'sydney']
+const prodRegions = ['us', 'eu', 'dublin', 'tokyo', 'virginia', 'oregon', 'frankfurt', 'sydney']
 const prodRegionsMap = {}
 const qaRegions = ['dublin', 'frankfurt', 'virginia']
 const qaRegionsMap = {}

--- a/lib/connect/regions.js
+++ b/lib/connect/regions.js
@@ -1,5 +1,4 @@
 'use strict'
-const cli = require('heroku-cli-util')
 const co = require('co')
 
 const prodRegions = ['us', 'eu', 'tokyo', 'virginia', 'oregon', 'frankfurt', 'sydney']


### PR DESCRIPTION
The `--region` flag still reigns supreme, if supplied, but the default now fetches the region from the app instead. Better yet, it only fetches from the app if the `--region` flag isn't supplied. So this should allow 99% of users to use the CLI without the `--region` flag, while still giving a backdoor for those who need it.

Using the Heroku API required making `determineRegion` asynchronous, which in turn requires a different way to call it (in addition to needing to pass in the Heroku API client). So there are a lot of files changed, but most of them are just a simple usage change.

I also reorganized `determineRegions` a bit and simplified it. Checking for `--region` first not only saves us an API call in some isolated cases, it also makes the `if` read as a positive, rather than a negative, which I find helps the `else` make a bit more sense. I also changed it to just throw an `Error` rather than using `cli.exit()`, since `cli.command` already catches errors and does the right thing with them.