### PR TITLE
Add --verbose/-v flag to connect:diagnose

### DIFF
--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -71,7 +71,7 @@ module.exports = {
       }
     }
 
-    if (!(didDisplayAnything || context.flags.verbose)) {
+    if (!didDisplayAnything && !context.flags.verbose) {
       cli.log(cli.color['green']('Everything appears to be fine'))
     }
   })),

--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -4,10 +4,16 @@ const regions = require('../../lib/connect/regions.js')
 const cli = require('heroku-cli-util')
 const co = require('co')
 
-function displayResults (results) {
+function displayResults (results, flags) {
   results.errors.forEach(displayResult('red'))
   results.warnings.forEach(displayResult('yellow'))
-  results.passes.forEach(displayResult('green', false))
+  if (flags.verbose) {
+    results.passes.forEach(displayResult('green', false))
+  }
+}
+
+function shouldDisplay (results, flags) {
+  return (results.errors.length > 0 || results.warnings.length > 0 || flags.verbose)
 }
 
 function displayResult (color, displayMessages) {
@@ -33,12 +39,14 @@ module.exports = {
   help: 'Checks a connection for common configuration errors. ',
   flags: [
     {name: 'resource', description: 'specific connection resource name', hasValue: true},
+    {name: 'verbose', char: 'v', description: 'display passed check information as well'},
     regions.flag
   ],
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
     context.region = yield regions.determineRegion(context, heroku)
+    let mappingResults
     let connection = yield api.withConnection(context, heroku)
     let results = yield cli.action('Diagnosing connection', co(function * () {
       let url = '/api/v3/connections/' + connection.id + '/validations'
@@ -47,12 +55,17 @@ module.exports = {
 
     cli.log() // Blank line to separate each section
     cli.styledHeader(`Connection: ${connection.name || connection.internal_name}`)
-    displayResults(results.json)
+    if (shouldDisplay(results.json, context.flags)) {
+      displayResults(results.json, context.flags)
+    }
 
     for (let objectName in results.json.mappings) {
-      cli.log() // Blank line to separate each section
-      cli.styledHeader(objectName)
-      displayResults(results.json.mappings[objectName])
+      mappingResults = results.json.mappings[objectName]
+      if (shouldDisplay(mappingResults, context.flags)) {
+        cli.log() // Blank line to separate each section
+        cli.styledHeader(objectName)
+        displayResults(mappingResults, context.flags)
+      }
     }
   })),
 


### PR DESCRIPTION
Only log warnings and errors and only display information about mappings
if there are warnings and errors to show.