### PR TITLE
Replace Toolbelt with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Heroku Connect Toolbelt Plugin
+Heroku Connect CLI Plugin
 ==================
 
 # Install

--- a/lib/connect/api.js
+++ b/lib/connect/api.js
@@ -15,7 +15,7 @@ let request = exports.request = function (context, method, path, data) {
   let headers = {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer ' + context.auth.password,
-    'Heroku-Client': 'toolbelt'
+    'Heroku-Client': 'cli'
   }
 
   // add data as querystring for GET request

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-connect-plugin",
   "description": "Heroku Connect plugin for Heroku CLI",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "Heroku (@heroku)",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroku-connect-plugin",
-  "description": "Heroku Connect plugin for Heroku Toolbelt",
+  "description": "Heroku Connect plugin for Heroku CLI",
   "version": "0.4.2",
   "author": "Heroku (@heroku)",
   "repository": {

--- a/test/commands/connect/state.js
+++ b/test/commands/connect/state.js
@@ -19,7 +19,7 @@ describe('connect:state', () => {
       reqheaders: {
         'content-type': 'application/json',
         'authorization': `Bearer ${password}`,
-        'heroku-client': 'toolbelt'
+        'heroku-client': 'cli'
       }
     })
       .get('/api/v3/connections')


### PR DESCRIPTION
The old name is Toolbelt and the new name is CLI, according to https://devcenter.heroku.com/articles/heroku-cli