### PR TITLE
Categorize skipped results in connect:diagnose output

### DIFF
--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -5,10 +5,11 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 
 function displayResults (results, flags) {
-  results.errors.forEach(displayResult('red'))
-  results.warnings.forEach(displayResult('yellow'))
+  results.errors.forEach(displayResult('RED', 'red'))
+  results.warnings.forEach(displayResult('YELLOW', 'yellow'))
   if (flags.verbose) {
-    results.passes.forEach(displayResult('green', false))
+    results.passes.forEach(displayResult('GREEN', 'green', false))
+    results.skips.forEach(displayResult('SKIPPED', 'dim', false))
   }
 }
 
@@ -16,13 +17,13 @@ function shouldDisplay (results, flags) {
   return (results.errors.length > 0 || results.warnings.length > 0 || flags.verbose)
 }
 
-function displayResult (color, displayMessages) {
+function displayResult (label, color, displayMessages) {
   // Default to displaying messages, unless overridden
   if (displayMessages === undefined) {
     displayMessages = true
   }
   return function (result) {
-    cli.log(cli.color[color](`${color.toUpperCase()}: ${result.display_name}`))
+    cli.log(cli.color[color](`${label}: ${result.display_name}`))
     if (displayMessages) {
       cli.log(result.message)
       if (result.doc_url) {
@@ -39,7 +40,7 @@ module.exports = {
   help: 'Checks a connection for common configuration errors. ',
   flags: [
     {name: 'resource', description: 'specific connection resource name', hasValue: true},
-    {name: 'verbose', char: 'v', description: 'display passed check information as well'},
+    {name: 'verbose', char: 'v', description: 'display passed and skipped check information as well'},
     regions.flag
   ],
   needsApp: true,

--- a/commands/connect/mapping-diagnose.js
+++ b/commands/connect/mapping-diagnose.js
@@ -15,6 +15,7 @@ module.exports = {
   ],
   flags: [
     {name: 'resource', description: 'specific connection resource name', hasValue: true},
+    {name: 'verbose', char: 'v', description: 'display passed and skipped check information as well'},
     regions.flag
   ],
   needsApp: true,
@@ -30,6 +31,6 @@ module.exports = {
 
     cli.log() // Blank line to separate each section
     cli.styledHeader(mapping.object_name)
-    diagnose.displayResults(results.json)
+    diagnose.displayResults(results.json, context.flags)
   }))
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-connect-plugin",
   "description": "Heroku Connect plugin for Heroku CLI",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "Heroku (@heroku)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a new grouping for skipped results and also fixes a bug that prevented `connect:mapping:diagnose` from working properly.

It shouldn't be published on npm until the API changes in https://github.com/heroku/herokuconnect/pull/5393 get deployed.

Refs https://github.com/heroku/herokuconnect/issues/5376