### PR TITLE
POC: Add connect:mapping:write-errors

### DIFF
--- a/commands/connect/mapping-write-errors.js
+++ b/commands/connect/mapping-write-errors.js
@@ -18,16 +18,20 @@ function * run (context, heroku) {
   if (errors.count === 0) {
     cli.log('No write errors in the last 24 hours')
   } else {
-    cli.table(errors.results, {
-      printHeader: true,
-      columns: [
-        {key: 'id', label: 'Trigger Log ID'},
-        {key: 'table_name', label: 'Table Name'},
-        {key: 'record_id', label: 'Table ID'},
-        {key: 'message', label: 'Error Message'},
-        {key: 'created_at', label: 'Created'}
-      ]
-    })
+    if (context.flags.json) {
+      cli.styledJSON(errors.results)
+    } else {
+      cli.table(errors.results, {
+        printHeader: true,
+        columns: [
+          {key: 'id', label: 'Trigger Log ID'},
+          {key: 'table_name', label: 'Table Name'},
+          {key: 'record_id', label: 'Table ID'},
+          {key: 'message', label: 'Error Message'},
+          {key: 'created_at', label: 'Created'}
+        ]
+      })
+    }
   }
 }
 
@@ -47,6 +51,11 @@ module.exports = {
       name: 'resource',
       description: 'specific connection resource name',
       hasValue: true
+    },
+    {
+      name: 'json',
+      description: 'print errors as styled JSON',
+      hasValue: false
     },
     regions.flag
   ],

--- a/commands/connect/mapping-write-errors.js
+++ b/commands/connect/mapping-write-errors.js
@@ -8,14 +8,14 @@ function * run (context, heroku) {
   context.region = yield regions.determineRegion(context, heroku)
   let mappingName = context.args.name
   let connection = yield api.withConnection(context, heroku)
-  let mapping = yield api.withMapping(connection, context.args.name)
+  let mapping = yield api.withMapping(connection, mappingName)
   let results = yield cli.action('Retrieving errors', co(function * () {
     let url = '/api/v3/mappings/' + mapping.id + '/errors'
     return yield api.request(context, 'GET', url)
   }))
   let errors = results.json
 
-  if (errors.count == 0) {
+  if (errors.count === 0) {
     cli.log('No write errors in the last 24 hours')
   } else {
     cli.table(errors.results, {

--- a/commands/connect/mapping-write-errors.js
+++ b/commands/connect/mapping-write-errors.js
@@ -1,0 +1,56 @@
+'use strict'
+const api = require('../../lib/connect/api.js')
+const regions = require('../../lib/connect/regions.js')
+const cli = require('heroku-cli-util')
+const co = require('co')
+
+function * run (context, heroku) {
+  context.region = yield regions.determineRegion(context, heroku)
+  let mappingName = context.args.name
+  let connection = yield api.withConnection(context, heroku)
+  let mapping = yield api.withMapping(connection, context.args.name)
+  let results = yield cli.action('Retrieving errors', co(function * () {
+    let url = '/api/v3/mappings/' + mapping.id + '/errors'
+    return yield api.request(context, 'GET', url)
+  }))
+  let errors = results.json
+
+  if (errors.count == 0) {
+    cli.log('No write errors in the last 24 hours')
+  } else {
+    cli.table(errors.results, {
+      printHeader: true,
+      columns: [
+        {key: 'id', label: 'Trigger Log ID'},
+        {key: 'table_name', label: 'Table Name'},
+        {key: 'record_id', label: 'Table ID'},
+        {key: 'message', label: 'Error Message'},
+        {key: 'created_at', label: 'Created'}
+      ]
+    })
+  }
+}
+
+module.exports = {
+  topic: 'connect',
+  command: 'mapping:write-errors',
+  description: 'Display the last 24 hours of write errors',
+  args: [
+    {
+      name: 'name',
+      optional: false,
+      description: 'Name of the mapping to retrieve errors for'
+    }
+  ],
+  flags: [
+    {
+      name: 'resource',
+      description: 'specific connection resource name',
+      hasValue: true
+    },
+    regions.flag
+  ],
+  needsApp: true,
+  needsAuth: true,
+  run: cli.command(co.wrap(run))
+}

--- a/index.js
+++ b/index.js
@@ -18,5 +18,6 @@ exports.commands = [
   require('./commands/connect/mapping-state'),
   require('./commands/connect/mapping-delete'),
   require('./commands/connect/mapping-reload'),
-  require('./commands/connect/mapping-diagnose')
+  require('./commands/connect/mapping-diagnose'),
+  require('./commands/connect/mapping-write-errors')
 ]


### PR DESCRIPTION
This allows customers to retrieve write errors from the API as a
proof-of-concept of how to view write-errors not in the dashboard and
not via PSQL