### PR TITLE
Simplify --resource lookup

### DIFF
--- a/lib/connect/api.js
+++ b/lib/connect/api.js
@@ -81,27 +81,8 @@ let request = exports.request = function (context, method, path, data) {
 let withUserConnections = exports.withUserConnections = co.wrap(function * (context, appName, flags, allowNone, heroku) {
   // global_config();
 
-  if (flags && flags.resource) {
-    cli.hush('Calling Platform API for resource id')
-
-    return co(function * () {
-      let addon
-      try {
-        addon = yield heroku.apps(appName).addons(flags.resource).info()
-      } catch (err) {
-        if (err.statusCode === 404) {
-          err.body.message = "Connection with resource name '" + flags.resource + "' not found"
-        }
-        throw err
-      }
-      flags.resource_id = addon.id
-      delete flags['resource']
-      return yield Promise.resolve(withUserConnections(context, appName, flags, allowNone, heroku))
-    })
-  }
-
   cli.hush('Retrieving user connections')
-  let response = yield request(context, 'GET', '/api/v3/connections', {deep: true, app: appName, resource_id: flags.resource_id})
+  let response = yield request(context, 'GET', '/api/v3/connections', {deep: true, app: appName, resource_name: flags.resource})
   return yield Promise.resolve(response.json.results)
 })
 

--- a/test/commands/connect/sf-auth.js
+++ b/test/commands/connect/sf-auth.js
@@ -19,12 +19,12 @@ describe('connect:sf:auth', () => {
 
   it('authenticates the user to Salesforce', () => {
     let appName = 'fake-app'
-    let resourceId = 'abcd-ef01'
+    let resourceName = 'abcd-ef01'
     let connectionId = '123'
     let password = 's3cr3t3'
     let apiWithPort = nock('https://connect-us.heroku.com:443')
       .get('/api/v3/connections')
-      .query({deep: true, app: appName, resource_id: resourceId})
+      .query({deep: true, app: appName, resource_name: resourceName})
       .reply(200, {results: [{id: connectionId}]})
     let apiWithoutPort = nock('https://connect-us.heroku.com')
       .post('/api/v3/connections/' + connectionId + '/authorize_url', {
@@ -36,7 +36,7 @@ describe('connect:sf:auth', () => {
     return sfAuthCmd.run({
       app: appName,
       flags: {
-        resource_id: resourceId,
+        resource_name: resourceName,
         login: undefined,
         region: 'us'
       },

--- a/test/commands/connect/sf-auth.js
+++ b/test/commands/connect/sf-auth.js
@@ -36,7 +36,7 @@ describe('connect:sf:auth', () => {
     return sfAuthCmd.run({
       app: appName,
       flags: {
-        resource_name: resourceName,
+        resource: resourceName,
         login: undefined,
         region: 'us'
       },

--- a/test/commands/connect/state.js
+++ b/test/commands/connect/state.js
@@ -13,7 +13,7 @@ describe('connect:state', () => {
 
   it('retrieves the state of the connect addon', () => {
     let appName = 'fake-app'
-    let resourceId = 'abcd-ef01'
+    let resourceName = 'abcd-ef01'
     let password = 's3cr3t3'
     let api = nock('https://connect-us.heroku.com:443', {
       reqheaders: {
@@ -23,13 +23,13 @@ describe('connect:state', () => {
       }
     })
       .get('/api/v3/connections')
-      .query({deep: true, app: appName, resource_id: resourceId})
+      .query({deep: true, app: appName, resource_name: resourceName})
       .reply(200, {results: [{state: 'NEW'}]})
 
     return stateCmd.run({
       app: appName,
       flags: {
-        resource_id: resourceId,
+        resource_name: resourceName,
         region: 'us'
       },
       auth: {

--- a/test/commands/connect/state.js
+++ b/test/commands/connect/state.js
@@ -29,7 +29,7 @@ describe('connect:state', () => {
     return stateCmd.run({
       app: appName,
       flags: {
-        resource_name: resourceName,
+        resource: resourceName,
         region: 'us'
       },
       auth: {


### PR DESCRIPTION
Our connection list endpoint can already accept `resource_name` directly as a search term, so we don't actually need to first lookup the resource ID from the platform API. We're using this as our main entry point into the API, so this should save us an API call pretty much across the board. If `--resource` isn't provided, the API call will supply an empty value, which will simply not get added to the query.