### PR TITLE
Fix showing connection state for all connections on an app

### DIFF
--- a/commands/connect/mapping-write-errors.js
+++ b/commands/connect/mapping-write-errors.js
@@ -22,7 +22,6 @@ function * run (context, heroku) {
       cli.styledJSON(errors.results)
     } else {
       cli.table(errors.results, {
-        printHeader: true,
         columns: [
           {key: 'id', label: 'Trigger Log ID'},
           {key: 'table_name', label: 'Table Name'},

--- a/commands/connect/state.js
+++ b/commands/connect/state.js
@@ -8,16 +8,23 @@ function * run (context, heroku) {
   context.region = yield regions.determineRegion(context, heroku)
   let connections = yield api.withUserConnections(context, context.app, context.flags, heroku)
 
-  if (context.flags.json) {
-    cli.styledJSON(connections)
+  if (!context.flags.resource) {
+    if (context.flags.json) {
+      cli.styledJSON(connections)
+    } else {
+      cli.table(connections, {
+        columns: [
+          {key: 'app_name', label: 'App'},
+          {key: 'db_key', label: 'Database'},
+          {key: 'schema_name', label: 'Schema'},
+          {key: 'state', label: 'State'}
+        ]
+      })
+    }
   } else {
-    cli.table(connections, {
-      columns: [
-        {key: 'app_name', label: 'App'},
-        {key: 'db_key', label: 'Database'},
-        {key: 'schema_name', label: 'Schema'},
-        {key: 'state', label: 'State'},
-      ],
+    // Retrieving a single resource
+    connections.forEach(function (connection) {
+      cli.log(connection.state)
     })
   }
 }

--- a/commands/connect/state.js
+++ b/commands/connect/state.js
@@ -14,7 +14,6 @@ function * run (context, heroku) {
     } else {
       cli.table(connections, {
         columns: [
-          {key: 'app_name', label: 'App'},
           {key: 'db_key', label: 'Database'},
           {key: 'schema_name', label: 'Schema'},
           {key: 'state', label: 'State'}

--- a/commands/connect/state.js
+++ b/commands/connect/state.js
@@ -8,9 +8,18 @@ function * run (context, heroku) {
   context.region = yield regions.determineRegion(context, heroku)
   let connections = yield api.withUserConnections(context, context.app, context.flags, heroku)
 
-  connections.forEach(function (connection) {
-    cli.log(connection.state)
-  })
+  if (context.flags.json) {
+    cli.styledJSON(connections)
+  } else {
+    cli.table(connections, {
+      columns: [
+        {key: 'app_name', label: 'App'},
+        {key: 'db_key', label: 'Database'},
+        {key: 'schema_name', label: 'Schema'},
+        {key: 'state', label: 'State'},
+      ],
+    })
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
The output looks like:

```
❯❯❯ heroku connect:state -a a-test-connect-app
Database      Schema      State
────────────  ──────────  ─────
DATABASE_URL  salesforce  IDLE
```

This also removes `printHeader` in `mapping:write-errors` as it's
apparently an invalid option.