### PR TITLE
Fix #85 -- Remove --login flag from sf:auth command

### DIFF
--- a/commands/connect/sf-auth.js
+++ b/commands/connect/sf-auth.js
@@ -40,9 +40,6 @@ function * run (context, heroku) {
       // can respond immediately after successful authorization
       'next': `http://localhost:${LOCAL_PORT}`
     }
-    if (context.flags.login) {
-      args.login_url = context.flags.login
-    }
 
     let response = yield api.request(context, 'POST', url, args)
     redir = response.json.redirect
@@ -62,7 +59,6 @@ module.exports = {
   help: 'Opens a browser to authorize a connection to a Salesforce Org',
   flags: [
     {name: 'callback', char: 'c', description: 'final callback URL', hasValue: true},
-    {name: 'login', char: 'l', description: 'alternate Salesforce login URL', hasValue: true},
     {name: 'resource', description: 'specific connection resource name', hasValue: true},
     regions.flag
   ],

--- a/test/commands/connect/sf-auth.js
+++ b/test/commands/connect/sf-auth.js
@@ -37,7 +37,6 @@ describe('connect:sf:auth', () => {
       app: appName,
       flags: {
         resource: resourceName,
-        login: undefined,
         region: 'us'
       },
       auth: {


### PR DESCRIPTION
Apparently this feature was never implemented into the API and
does not serve any purpose.