### PR TITLE
Rename restart to recover

### DIFF
--- a/commands/connect/recover.js
+++ b/commands/connect/recover.js
@@ -6,8 +6,9 @@ const co = require('co')
 
 module.exports = {
   topic: 'connect',
-  command: 'restart',
-  description: 'Restart a connection',
+  command: 'recover',
+  aliases: ['connect:restart'],
+  description: 'Recover a connection',
   help: 'Clears errors and attempts to resume sync operations',
   flags: [
     {name: 'resource', description: 'specific connection resource name', hasValue: true},
@@ -17,7 +18,7 @@ module.exports = {
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
     context.region = yield regions.determineRegion(context, heroku)
-    yield cli.action('restarting connection', co(function * () {
+    yield cli.action('recovering connection', co(function * () {
       let connection = yield api.withConnection(context, heroku)
       let url = '/api/v3/connections/' + connection.id + '/actions/restart'
       yield api.request(context, 'POST', url)

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ exports.commands = [
   require('./commands/connect/export'),
   require('./commands/connect/pause'),
   require('./commands/connect/resume'),
-  require('./commands/connect/restart'),
+  require('./commands/connect/recover'),
   require('./commands/connect/sf-auth'),
   require('./commands/connect/db-set'),
   require('./commands/connect/diagnose'),


### PR DESCRIPTION
This better matches what the Connect dashboard shows users who need the
same functionality. Also "restart" sounds a bit more destructive than
recover actually is.