### PR TITLE
Fix bug introduced by upgrading inquirer

### DIFF
--- a/commands/connect/db-set.js
+++ b/commands/connect/db-set.js
@@ -54,7 +54,7 @@ module.exports = {
         default: context.flags.schema || 'salesforce',
         when: !context.flags.schema
       }
-    ], co.wrap(function * (answers) {
+    ]).then(co.wrap(function * (answers) {
       for (let key in answers) {
         data[key] = answers[key]
       }


### PR DESCRIPTION
Inquirer changed its API to rely on Promises. Now, when we create a
prompt, we only pass the choices, and receive the answers as a promise.

This updates connect:db:set to rely on that new API.

Closes gh-92