### PR TITLE
Consider API version flag

### DIFF
--- a/commands/connect/sf-auth.js
+++ b/commands/connect/sf-auth.js
@@ -49,6 +49,10 @@ function * run (context, heroku) {
       args.domain = context.flags.domain
     }
 
+    if (context.flags.api_version) {
+      args.api_version = context.flags.api_version
+    }
+
     let response = yield api.request(context, 'POST', url, args)
     redir = response.json.redirect
 
@@ -69,6 +73,7 @@ module.exports = {
     {name: 'callback', char: 'c', description: 'final callback URL', hasValue: true},
     {name: 'environment', char: 'e', description: '"production", "sandbox", or "custom" [defaults to "production"]', hasValue: true},
     {name: 'domain', char: 'd', description: 'specify a custom login domain (if using a "custom" environment)', hasValue: true},
+    {name: 'api_version', char: 'v', description: 'specify a Salesforce API version to use [defaults to the latest supported]', hasValue: true},
     {name: 'resource', description: 'specific connection resource name', hasValue: true},
     regions.flag
   ],

--- a/test/commands/connect/sf-auth.js
+++ b/test/commands/connect/sf-auth.js
@@ -22,6 +22,7 @@ describe('connect:sf:auth', () => {
     let resourceName = 'abcd-ef01'
     let connectionId = '123'
     let password = 's3cr3t3'
+    let api_version = '45'
     let apiWithPort = nock('https://connect-us.heroku.com:443')
       .get('/api/v3/connections')
       .query({deep: true, app: appName, resource_name: resourceName})
@@ -29,13 +30,15 @@ describe('connect:sf:auth', () => {
     let apiWithoutPort = nock('https://connect-us.heroku.com')
       .post('/api/v3/connections/' + connectionId + '/authorize_url', {
         environment: 'production',
-        next: 'http://localhost:18000'
+        next: 'http://localhost:18000',
+        api_version: api_version,
       })
       .reply(201, {redirect: 'redirect-uri'})
 
     return sfAuthCmd.run({
       app: appName,
       flags: {
+        api_version: api_version,
         resource: resourceName,
         region: 'us'
       },

--- a/test/commands/connect/sf-auth.js
+++ b/test/commands/connect/sf-auth.js
@@ -22,7 +22,7 @@ describe('connect:sf:auth', () => {
     let resourceName = 'abcd-ef01'
     let connectionId = '123'
     let password = 's3cr3t3'
-    let api_version = '45'
+    let apiVersion = '45'
     let apiWithPort = nock('https://connect-us.heroku.com:443')
       .get('/api/v3/connections')
       .query({deep: true, app: appName, resource_name: resourceName})
@@ -31,14 +31,14 @@ describe('connect:sf:auth', () => {
       .post('/api/v3/connections/' + connectionId + '/authorize_url', {
         environment: 'production',
         next: 'http://localhost:18000',
-        api_version: api_version,
+        api_version: apiVersion
       })
       .reply(201, {redirect: 'redirect-uri'})
 
     return sfAuthCmd.run({
       app: appName,
       flags: {
-        api_version: api_version,
+        api_version: apiVersion,
         resource: resourceName,
         region: 'us'
       },


### PR DESCRIPTION
Greetings fellows,

There is an optional JSON parameter called "api_version" that allows specifying a Salesforce API version to use:
https://devcenter.heroku.com/articles/heroku-connect-api#step-6-authenticate-the-connection-to-your-salesforce-org

This PR attempts to add that parameter to CLI tooling.

Please, tell me what do you think of this and if this is a good feature to consider, tell me how can I improve and properly test it.
Thanks!