### PR TITLE
Improve Error Message of connect:info Command

### DIFF
--- a/commands/connect/info.js
+++ b/commands/connect/info.js
@@ -18,7 +18,11 @@ module.exports = {
     let connections = yield api.withUserConnections(context, context.app, context.flags, true, heroku)
 
     if (connections.length === 0) {
-      cli.error('No connection(s) found')
+      const instanceName = process.env['CONNECT_ADDON'] === 'connectqa' ? 'connectqa' : 'herokuconnect'
+      cli.error('No connection found. You may need to use addons:open to make it accessible to the CLI.')
+      cli.error('')
+      cli.error('For Example:')
+      cli.error(`heroku addons:open ${instanceName} -a ${context.app}`)
     } else {
       connections.forEach(function (connection) {
         cli.styledHeader(`Connection [${connection.id}] / ${connection.resource_name} (${connection.state})`)

--- a/test/commands/connect/info.js
+++ b/test/commands/connect/info.js
@@ -98,7 +98,8 @@ describe('connect:info', () => {
       .then(() => {
         expect(cli.stdout, 'to be empty')
       })
-      .then(() => expect(cli.stderr, 'to contain', 'No connection(s) found'))
+      .then(() => expect(cli.stderr, 'to contain', 'No connection found'))
+      .then(() => expect(cli.stderr, 'to contain', `heroku addons:open connectqa -a fake-app`))
       .then(() => discoveryApi.done())
   })
 })


### PR DESCRIPTION
As per user feedback, the error message from the `connect:info` command can be confusing if the user hasn't yet `addons:open`ed that particular connection.

This PR updates the error message of `connect:info` with a helpful command that should at least get users on the right track.

![Screen Shot 2019-05-07 at 9 34 58 AM](https://user-images.githubusercontent.com/5148596/57303678-d06c7c80-70ab-11e9-8831-5f1a553ce1d1.png)
