### PR TITLE
Add back ability to check for access to addons without addons:open

### DIFF
--- a/commands/connect-events/info.js
+++ b/commands/connect-events/info.js
@@ -10,12 +10,22 @@ module.exports = {
   description: 'display connection information',
   help: 'display connection information',
   flags: [
-    {name: 'resource', description: 'specific connection resource name', hasValue: true}
+    {name: 'resource', description: 'specific connection resource name', hasValue: true},
+    {name: 'check-for-new', char: 'c', description: 'check for access to any new connections', hasValue: false}
   ],
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(function * (context, heroku) {
-    let connections = yield api.withUserConnections(context, context.app, context.flags, true, heroku, api.ADDON_TYPE_EVENTS)
+    let connections
+
+    if (context.flags['check-for-new']) {
+      connections = yield api.requestAppAccess(context, context.app, context.flags, true, heroku, api.ADDON_TYPE_EVENTS)
+    } else {
+      connections = yield api.withUserConnections(context, context.app, context.flags, true, heroku, api.ADDON_TYPE_EVENTS)
+      if (connections.length === 0) {
+        connections = yield api.requestAppAcess(context, context.app, context.flags, true, heroku, api.ADDON_TYPE_EVENTS)
+      }
+    }
 
     if (connections.length === 0) {
       const instanceName = process.env['CONNECT_ADDON'] === 'connectqa' ? 'platformeventsqa' : 'herokuconnect'

--- a/lib/clients/discovery.js
+++ b/lib/clients/discovery.js
@@ -21,6 +21,12 @@ class DiscoveryClient {
     const url = `/connections?app=${appName}${resourceNameQueryParam}${addonTypeQueryParam}`
     return this.client(url)
   }
+
+  requestAppAccess (appName, addonType) {
+    const addonTypeQueryParam = addonType ? `?addon_type=${addonType}` : ''
+    const url = `/auth/${appName}${addonTypeQueryParam}`
+    return this.client({url: url, method: 'POST'})
+  }
 }
 
 exports.DiscoveryClient = DiscoveryClient

--- a/lib/connect/api.js
+++ b/lib/connect/api.js
@@ -20,7 +20,7 @@ let request = exports.request = function (context, method, url, data) {
   })
 }
 
-exports.withUserConnections = co.wrap(function * (context, appName, flags, allowNone, heroku, addonType) {
+const withUserConnections = exports.withUserConnections = co.wrap(function * (context, appName, flags, allowNone, heroku, addonType) {
   const connectClient = new ConnectClient(context)
   const discoveryClient = new DiscoveryClient(context)
 
@@ -131,6 +131,15 @@ exports.withStreams = function (context, connections) {
     })
     const aggregatedConnectionsResponse = yield Promise.all(fetchConnectionStreams)
     return yield Promise.resolve(aggregatedConnectionsResponse)
+  })
+}
+
+exports.requestAppAccess = function (context, app, flags, allowNone, heroku, addonType) {
+  return co(function * () {
+    const discoveryClient = new DiscoveryClient(context)
+    let response = yield discoveryClient.requestAppAccess(app, addonType)
+    yield Promise.resolve(response.json)
+    return yield withUserConnections(context, app, flags, allowNone, heroku, addonType)
   })
 }
 

--- a/test/commands/connect/info.js
+++ b/test/commands/connect/info.js
@@ -81,7 +81,14 @@ describe('connect:info', () => {
   it('returns an error message if no connections are found', () => {
     let appName = 'fake-app'
     let resourceName = 'abcd-ef01'
+    let check = nock('https://hc-central-qa.herokai.com/', {headers})
+      .post('/auth/fake-app')
+      .reply(200, {results: []})
     let discoveryApi = nock('https://hc-central-qa.herokai.com/', {headers})
+      .get('/connections')
+      .query({app: appName, resource_name: resourceName})
+      .reply(200, {results: []})
+    let discoveryApi2 = nock('https://hc-central-qa.herokai.com/', {headers})
       .get('/connections')
       .query({app: appName, resource_name: resourceName})
       .reply(200, {results: []})
@@ -101,5 +108,7 @@ describe('connect:info', () => {
       .then(() => expect(cli.stderr, 'to contain', 'No connection found'))
       .then(() => expect(cli.stderr, 'to contain', `heroku addons:open connectqa -a fake-app`))
       .then(() => discoveryApi.done())
+      .then(() => discoveryApi2.done())
+      .then(() => check.done())
   })
 })


### PR DESCRIPTION
This functionality got pulled out when the discovery service was added because we didn't have an equivalent endpoint in the discovery service. This PR brings back that behavior. See [this line](https://github.com/heroku/heroku-connect-plugin/pull/99/files#diff-a541cf0e44c990d4833aa61573da7d5dL25) for the removal of the original behavior.