### PR TITLE
Make `connect:diagnose` poll for results

### DIFF
--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -32,7 +32,7 @@ function displayResult (label, color, displayMessages) {
   }
 }
 
-function timeout(duration) {
+function timeout (duration) {
   return new Promise(resolve => {
     setTimeout(resolve, duration)
   })
@@ -57,7 +57,7 @@ module.exports = {
     let results = yield cli.action('Diagnosing connection', co(function * () {
       let url = '/api/v3/connections/' + connection.id + '/validations'
       try {
-        let { data: { result_url: resultUrl }} = yield api.request(context, 'POST', url)
+        let {data: {result_url: resultUrl}} = yield api.request(context, 'POST', url)
 
         while (true) {
           let response = yield api.request(context, 'GET', resultUrl)
@@ -68,7 +68,7 @@ module.exports = {
 
           yield timeout(500)
         }
-      } catch(err) {
+      } catch (err) {
         cli.error(err)
       }
     }))

--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -59,12 +59,20 @@ module.exports = {
       try {
         let {data: {result_url: resultUrl}} = yield api.request(context, 'POST', url)
 
+        let i = 0
+
         while (true) {
+          if (i > 600) {
+            cli.error('There was an issue retrieving validations')
+            break
+          }
           let response = yield api.request(context, 'GET', resultUrl)
 
           if (response.status === 200) {
             return response.data
           }
+
+          i++
 
           yield timeout(500)
         }

--- a/commands/connect/diagnose.js
+++ b/commands/connect/diagnose.js
@@ -32,6 +32,12 @@ function displayResult (label, color, displayMessages) {
   }
 }
 
+function timeout(duration) {
+  return new Promise(resolve => {
+    setTimeout(resolve, duration)
+  })
+}
+
 module.exports = {
   topic: 'connect',
   command: 'diagnose',
@@ -50,18 +56,32 @@ module.exports = {
     context.region = connection.region_url
     let results = yield cli.action('Diagnosing connection', co(function * () {
       let url = '/api/v3/connections/' + connection.id + '/validations'
-      return yield api.request(context, 'GET', url)
+      try {
+        let { data: { result_url: resultUrl }} = yield api.request(context, 'POST', url)
+
+        while (true) {
+          let response = yield api.request(context, 'GET', resultUrl)
+
+          if (response.status === 200) {
+            return response.data
+          }
+
+          yield timeout(500)
+        }
+      } catch(err) {
+        cli.error(err)
+      }
     }))
 
     cli.log() // Blank line to separate each section
     cli.styledHeader(`Connection: ${connection.name || connection.internal_name}`)
-    if (shouldDisplay(results.data, context.flags)) {
+    if (shouldDisplay(results, context.flags)) {
       didDisplayAnything = true
-      displayResults(results.data, context.flags)
+      displayResults(results, context.flags)
     }
 
-    for (let objectName in results.data.mappings) {
-      mappingResults = results.data.mappings[objectName]
+    for (let objectName in results.mappings) {
+      mappingResults = results.mappings[objectName]
       if (shouldDisplay(mappingResults, context.flags)) {
         didDisplayAnything = true
         cli.log() // Blank line to separate each section

--- a/test/commands/connect/diagnose.js
+++ b/test/commands/connect/diagnose.js
@@ -55,41 +55,7 @@ describe('connect:diagnose', () => {
       .reply(202)
       .get('/api/v3/connections/1234/validations/456')
       .reply(200, {
-        // data: {
-        passes: [
-          {
-            rule_id: 'NUM_MAPPINGS_WITHIN_LIMIT',
-            display_name: 'Number of Mappings',
-            status: 'PASSED',
-            message: 'Connection has no more than 100 mappings.',
-            doc_url:
-                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-number-of-mappings'
-          },
-          {
-            rule_id: 'HEROKU_POSTGRES_REQUIRED',
-            display_name: 'Heroku Postgres',
-            status: 'PASSED',
-            message: 'Database is a Heroku Postgres addon.',
-            doc_url:
-                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-heroku-postgres'
-          },
-          {
-            rule_id: 'REGIONS_SHOULD_MATCH',
-            display_name: 'Data Locality',
-            status: 'PASSED',
-            message: "Connection and app are both in the 'eu' region.",
-            doc_url:
-                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-data-locality'
-          },
-          {
-            rule_id: 'SHOULD_HAVE_VALID_SF_PERMISSIONS',
-            display_name: 'View/Modify All Data',
-            status: 'PASSED',
-            message: 'Salesforce user has appropriate permissions.',
-            doc_url:
-                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-view-modify-all-data'
-          }
-        ],
+        passes: [],
         warnings: [
           {
             rule_id: 'MUST_USE_RECENT_API_VERSION',
@@ -110,17 +76,7 @@ describe('connect:diagnose', () => {
           }
         ],
         errors: [],
-        skips: [
-          {
-            rule_id: 'PAID_PLAN_MUST_HAVE_PAID_DATABASE',
-            display_name: 'Database Plan',
-            status: 'SKIPPED',
-            message: 'Not applicable for the demo plan.',
-            doc_url:
-                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-database-plan'
-          }
-        ]
-        // }
+        skips: []
       })
 
     return cmd

--- a/test/commands/connect/diagnose.js
+++ b/test/commands/connect/diagnose.js
@@ -1,16 +1,16 @@
 /* globals describe beforeEach it */
 
-const cli = require('heroku-cli-util');
-const nock = require('nock');
-const expect = require('unexpected');
-const cmd = require('../../../commands/connect/diagnose');
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const expect = require('unexpected')
+const cmd = require('../../../commands/connect/diagnose')
 
-const password = 's3cr3t3';
+const password = 's3cr3t3'
 const headers = {
   'content-type': 'application/json',
   authorization: `Bearer ${password}`,
   'heroku-client': 'cli'
-};
+}
 
 describe.only('connect:diagnose', () => {
   // prevent stdout/stderr from displaying
@@ -18,7 +18,7 @@ describe.only('connect:diagnose', () => {
   beforeEach(() => cli.mockConsole())
 
   it('runs validations with polling', () => {
-    let appName = 'fake-app';
+    let appName = 'fake-app'
 
     let discoveryApi = nock('https://hc-central-qa.herokai.com/', { headers })
       .get('/connections')
@@ -29,7 +29,7 @@ describe.only('connect:diagnose', () => {
             detail_url: 'https://hc-virginia-qa.herokai.com/connections/1234'
           }
         ]
-      });
+      })
 
     const connectionData = {
       id: 1234,
@@ -38,12 +38,12 @@ describe.only('connect:diagnose', () => {
       state: 'IDLE',
       schema_name: 'salesforce',
       region_url: 'https://hc-virginia-qa.herokai.com/'
-    };
+    }
 
     let connectionDetailApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
       .get('/connections/1234')
       .query({ deep: true })
-      .reply(200, connectionData);
+      .reply(200, connectionData)
 
     let connectionValidationApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
       .post('/api/v3/connections/1234/validations')
@@ -56,72 +56,72 @@ describe.only('connect:diagnose', () => {
       .get('/api/v3/connections/1234/validations/456')
       .reply(200, {
         // data: {
-          passes: [
-            {
-              rule_id: 'NUM_MAPPINGS_WITHIN_LIMIT',
-              display_name: 'Number of Mappings',
-              status: 'PASSED',
-              message: 'Connection has no more than 100 mappings.',
-              doc_url:
+        passes: [
+          {
+            rule_id: 'NUM_MAPPINGS_WITHIN_LIMIT',
+            display_name: 'Number of Mappings',
+            status: 'PASSED',
+            message: 'Connection has no more than 100 mappings.',
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-number-of-mappings'
-            },
-            {
-              rule_id: 'HEROKU_POSTGRES_REQUIRED',
-              display_name: 'Heroku Postgres',
-              status: 'PASSED',
-              message: 'Database is a Heroku Postgres addon.',
-              doc_url:
+          },
+          {
+            rule_id: 'HEROKU_POSTGRES_REQUIRED',
+            display_name: 'Heroku Postgres',
+            status: 'PASSED',
+            message: 'Database is a Heroku Postgres addon.',
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-heroku-postgres'
-            },
-            {
-              rule_id: 'REGIONS_SHOULD_MATCH',
-              display_name: 'Data Locality',
-              status: 'PASSED',
-              message: "Connection and app are both in the 'eu' region.",
-              doc_url:
+          },
+          {
+            rule_id: 'REGIONS_SHOULD_MATCH',
+            display_name: 'Data Locality',
+            status: 'PASSED',
+            message: "Connection and app are both in the 'eu' region.",
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-data-locality'
-            },
-            {
-              rule_id: 'SHOULD_HAVE_VALID_SF_PERMISSIONS',
-              display_name: 'View/Modify All Data',
-              status: 'PASSED',
-              message: 'Salesforce user has appropriate permissions.',
-              doc_url:
+          },
+          {
+            rule_id: 'SHOULD_HAVE_VALID_SF_PERMISSIONS',
+            display_name: 'View/Modify All Data',
+            status: 'PASSED',
+            message: 'Salesforce user has appropriate permissions.',
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-view-modify-all-data'
-            }
-          ],
-          warnings: [
-            {
-              rule_id: 'MUST_USE_RECENT_API_VERSION',
-              display_name: 'Salesforce API Version',
-              status: 'FAILED',
-              message:
+          }
+        ],
+        warnings: [
+          {
+            rule_id: 'MUST_USE_RECENT_API_VERSION',
+            display_name: 'Salesforce API Version',
+            status: 'FAILED',
+            message:
                 'The latest available Salesforce API version is 47.0. Your connection is using version 44.0. You should re-create your connection to use the latest version.',
-              doc_url:
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-salesforce-api-version'
-            },
-            {
-              rule_id: 'SHOULD_HAVE_LOG_DRAIN',
-              display_name: 'Configured Logging',
-              status: 'FAILED',
-              message: 'App does not have logging configured.',
-              doc_url:
+          },
+          {
+            rule_id: 'SHOULD_HAVE_LOG_DRAIN',
+            display_name: 'Configured Logging',
+            status: 'FAILED',
+            message: 'App does not have logging configured.',
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-configured-log-drain'
-            }
-          ],
-          errors: [],
-          skips: [
-            {
-              rule_id: 'PAID_PLAN_MUST_HAVE_PAID_DATABASE',
-              display_name: 'Database Plan',
-              status: 'SKIPPED',
-              message: 'Not applicable for the demo plan.',
-              doc_url:
+          }
+        ],
+        errors: [],
+        skips: [
+          {
+            rule_id: 'PAID_PLAN_MUST_HAVE_PAID_DATABASE',
+            display_name: 'Database Plan',
+            status: 'SKIPPED',
+            message: 'Not applicable for the demo plan.',
+            doc_url:
                 'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-database-plan'
-            }
-          ]
+          }
+        ]
         // }
-      });
+      })
 
     return cmd
       .run({
@@ -140,7 +140,12 @@ YELLOW: Configured Logging
 App does not have logging configured.
 https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-configured-log-drain
 `
-        );
-      });
-  });
-});
+        )
+      })
+      .then(() => {
+        discoveryApi.done()
+        connectionDetailApi.done()
+        connectionValidationApi.done()
+      })
+  })
+})

--- a/test/commands/connect/diagnose.js
+++ b/test/commands/connect/diagnose.js
@@ -1,0 +1,146 @@
+/* globals describe beforeEach it */
+
+const cli = require('heroku-cli-util');
+const nock = require('nock');
+const expect = require('unexpected');
+const cmd = require('../../../commands/connect/diagnose');
+
+const password = 's3cr3t3';
+const headers = {
+  'content-type': 'application/json',
+  authorization: `Bearer ${password}`,
+  'heroku-client': 'cli'
+};
+
+describe.only('connect:diagnose', () => {
+  // prevent stdout/stderr from displaying
+  // redirects to cli.stdout/cli.stderr instead
+  beforeEach(() => cli.mockConsole())
+
+  it('runs validations with polling', () => {
+    let appName = 'fake-app';
+
+    let discoveryApi = nock('https://hc-central-qa.herokai.com/', { headers })
+      .get('/connections')
+      .query({ app: appName })
+      .reply(200, {
+        results: [
+          {
+            detail_url: 'https://hc-virginia-qa.herokai.com/connections/1234'
+          }
+        ]
+      });
+
+    const connectionData = {
+      id: 1234,
+      name: 'awesome-connection-1234',
+      db_key: 'DATABASE_URL',
+      state: 'IDLE',
+      schema_name: 'salesforce',
+      region_url: 'https://hc-virginia-qa.herokai.com/'
+    };
+
+    let connectionDetailApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/connections/1234')
+      .query({ deep: true })
+      .reply(200, connectionData);
+
+    let connectionValidationApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .post('/api/v3/connections/1234/validations')
+      .reply(202, {
+        result_url: 'https://hc-virginia-qa.herokai.com/api/v3/connections/1234/validations/456'
+      })
+      .get('/api/v3/connections/1234/validations/456')
+      .twice()
+      .reply(202)
+      .get('/api/v3/connections/1234/validations/456')
+      .reply(200, {
+        // data: {
+          passes: [
+            {
+              rule_id: 'NUM_MAPPINGS_WITHIN_LIMIT',
+              display_name: 'Number of Mappings',
+              status: 'PASSED',
+              message: 'Connection has no more than 100 mappings.',
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-number-of-mappings'
+            },
+            {
+              rule_id: 'HEROKU_POSTGRES_REQUIRED',
+              display_name: 'Heroku Postgres',
+              status: 'PASSED',
+              message: 'Database is a Heroku Postgres addon.',
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-heroku-postgres'
+            },
+            {
+              rule_id: 'REGIONS_SHOULD_MATCH',
+              display_name: 'Data Locality',
+              status: 'PASSED',
+              message: "Connection and app are both in the 'eu' region.",
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-data-locality'
+            },
+            {
+              rule_id: 'SHOULD_HAVE_VALID_SF_PERMISSIONS',
+              display_name: 'View/Modify All Data',
+              status: 'PASSED',
+              message: 'Salesforce user has appropriate permissions.',
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-view-modify-all-data'
+            }
+          ],
+          warnings: [
+            {
+              rule_id: 'MUST_USE_RECENT_API_VERSION',
+              display_name: 'Salesforce API Version',
+              status: 'FAILED',
+              message:
+                'The latest available Salesforce API version is 47.0. Your connection is using version 44.0. You should re-create your connection to use the latest version.',
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-salesforce-api-version'
+            },
+            {
+              rule_id: 'SHOULD_HAVE_LOG_DRAIN',
+              display_name: 'Configured Logging',
+              status: 'FAILED',
+              message: 'App does not have logging configured.',
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-configured-log-drain'
+            }
+          ],
+          errors: [],
+          skips: [
+            {
+              rule_id: 'PAID_PLAN_MUST_HAVE_PAID_DATABASE',
+              display_name: 'Database Plan',
+              status: 'SKIPPED',
+              message: 'Not applicable for the demo plan.',
+              doc_url:
+                'https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-database-plan'
+            }
+          ]
+        // }
+      });
+
+    return cmd
+      .run({
+        app: appName,
+        flags: {}
+      })
+      .then(() => {
+        expect(
+          cli.stdout,
+          'to contain',
+          `=== Connection: awesome-connection-1234
+YELLOW: Salesforce API Version
+The latest available Salesforce API version is 47.0. Your connection is using version 44.0. You should re-create your connection to use the latest version.
+https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-salesforce-api-version
+YELLOW: Configured Logging
+App does not have logging configured.
+https://devcenter.heroku.com/articles/heroku-connect-diagnose#check-configured-log-drain
+`
+        );
+      });
+  });
+});

--- a/test/commands/connect/diagnose.js
+++ b/test/commands/connect/diagnose.js
@@ -12,7 +12,7 @@ const headers = {
   'heroku-client': 'cli'
 }
 
-describe.only('connect:diagnose', () => {
+describe('connect:diagnose', () => {
   // prevent stdout/stderr from displaying
   // redirects to cli.stdout/cli.stderr instead
   beforeEach(() => cli.mockConsole())


### PR DESCRIPTION
This PR closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007bT6rIAE/view.

It updates `connect:diagnose` to use the new asynchronous endpoint for connection validations.