### PR TITLE
feat(connect): add schema-diff command

### DIFF
--- a/commands/connect/schema-diff.js
+++ b/commands/connect/schema-diff.js
@@ -1,0 +1,79 @@
+import { Command, flags } from '@heroku-cli/command'
+import cli from '@heroku/heroku-cli-util'
+import * as api from '../../lib/connect/api.js'
+
+export default class ConnectSchemaDiff extends Command {
+  static description = 'compare the schema of mappings in a connection between the current and a target Salesforce API version'
+
+  static help = 'Compares each mapping\'s Salesforce schema as it exists at the connection\'s current API version against a target API version, and reports per-mapping field-level changes. Use this before running connect:upgrade-api-version.'
+
+  static flags = {
+    app: flags.app({ required: true }),
+    resource: flags.string({ description: 'specific connection resource name' }),
+    'target-version': flags.string({ description: 'Salesforce API version to compare against (e.g. 61.0). Defaults to the latest supported version.' }),
+    json: flags.boolean({ description: 'print output as json' })
+  }
+
+  async run () {
+    const { flags } = await this.parse(ConnectSchemaDiff)
+    const context = {
+      app: flags.app,
+      flags,
+      args: {},
+      auth: { password: this.heroku.auth }
+    }
+
+    const connection = await api.withConnection(context, this.heroku)
+    context.region = connection.region_url
+
+    let url = `/api/v3/connections/${connection.id}/schema-diff`
+    if (flags['target-version']) {
+      if (!isValidApiVersion(flags['target-version'])) {
+        cli.error(`Invalid --target-version "${flags['target-version']}". Expected a Salesforce API version like "61.0".`)
+        return
+      }
+      url += `?target_version=${encodeURIComponent(flags['target-version'])}`
+    }
+
+    const response = await cli.action(
+      'Comparing schemas',
+      api.request(context, 'GET', url)
+    )
+    const result = response.data
+
+    if (flags.json) {
+      cli.styledJSON(result)
+      return
+    }
+
+    cli.log()
+    cli.styledHeader(`Connection: ${connection.name || connection.internal_name}`)
+    cli.log(`Current API Version: ${result.current_api_version}`)
+    cli.log(`Target API Version:  ${result.target_api_version}`)
+    cli.log()
+
+    cli.table(result.mappings, {
+      columns: [
+        { key: 'name', label: 'Mapping' },
+        {
+          key: 'fields_have_changed',
+          label: 'Status',
+          format: (changed, row) => {
+            if (!changed) return cli.color.green('no changes')
+            // Backend may surface has_unsafe_changes once the upgrade work lands.
+            // Until then, all "changed" rows render the same.
+            if (row.has_unsafe_changes === true) return cli.color.red('changed (unsafe)')
+            if (row.has_unsafe_changes === false) return cli.color.yellow('changed (safe)')
+            return cli.color.yellow('changed')
+          }
+        },
+        { key: 'result_message', label: 'Details' }
+      ]
+    })
+    cli.log()
+  }
+}
+
+function isValidApiVersion (value) {
+  return /^\d{1,3}\.\d$/.test(value)
+}

--- a/commands/connect/schema-diff.js
+++ b/commands/connect/schema-diff.js
@@ -60,8 +60,6 @@ export default class ConnectSchemaDiff extends Command {
           label: 'Status',
           format: (changed, row) => {
             if (!changed) return cli.color.green('no changes')
-            // Backend may surface has_unsafe_changes once the upgrade work lands.
-            // Until then, all "changed" rows render the same.
             if (row.has_unsafe_changes === true) return cli.color.red('changed (unsafe)')
             if (row.has_unsafe_changes === false) return cli.color.yellow('changed (safe)')
             return cli.color.yellow('changed')

--- a/commands/connect/schema-diff.js
+++ b/commands/connect/schema-diff.js
@@ -1,11 +1,18 @@
 import { Command, flags } from '@heroku-cli/command'
 import cli from '@heroku/heroku-cli-util'
 import * as api from '../../lib/connect/api.js'
+import { apiVersionFloor, isValidApiVersion } from '../../lib/connect/api-version.js'
 
 export default class ConnectSchemaDiff extends Command {
-  static description = 'compare the schema of mappings in a connection between the current and a target Salesforce API version'
+  static description = `compare the schema of mappings in a connection between the current and a target Salesforce API version
 
-  static help = 'Compares each mapping\'s Salesforce schema as it exists at the connection\'s current API version against a target API version, and reports per-mapping field-level changes. Use this before running connect:upgrade-api-version.'
+Compares each mapping's Salesforce schema as it exists at the connection's current API version against a target API version, and reports per-mapping field-level changes. Use this before running connect:upgrade-api-version.`
+
+  static examples = [
+    '$ heroku connect:schema-diff --app my-app',
+    '$ heroku connect:schema-diff --app my-app --target-version 61.0',
+    '$ heroku connect:schema-diff --app my-app --json'
+  ]
 
   static flags = {
     app: flags.app({ required: true }),
@@ -16,6 +23,14 @@ export default class ConnectSchemaDiff extends Command {
 
   async run () {
     const { flags } = await this.parse(ConnectSchemaDiff)
+
+    if (flags['target-version'] && !isValidApiVersion(flags['target-version'])) {
+      this.error(
+        `Invalid --target-version "${flags['target-version']}". Expected a Salesforce API version like "61.0" (>= ${apiVersionFloor()}.0).`,
+        { exit: 2 }
+      )
+    }
+
     const context = {
       app: flags.app,
       flags,
@@ -26,18 +41,13 @@ export default class ConnectSchemaDiff extends Command {
     const connection = await api.withConnection(context, this.heroku)
     context.region = connection.region_url
 
-    let url = `/api/v3/connections/${connection.id}/schema-diff`
-    if (flags['target-version']) {
-      if (!isValidApiVersion(flags['target-version'])) {
-        cli.error(`Invalid --target-version "${flags['target-version']}". Expected a Salesforce API version like "61.0".`)
-        return
-      }
-      url += `?target_version=${encodeURIComponent(flags['target-version'])}`
-    }
+    const params = flags['target-version']
+      ? { target_version: flags['target-version'] }
+      : undefined
 
     const response = await cli.action(
       'Comparing schemas',
-      api.request(context, 'GET', url)
+      api.request(context, 'GET', `/api/v3/connections/${connection.id}/schema-diff`, undefined, params)
     )
     const result = response.data
 
@@ -52,14 +62,19 @@ export default class ConnectSchemaDiff extends Command {
     cli.log(`Target API Version:  ${result.target_api_version}`)
     cli.log()
 
-    cli.table(result.mappings, {
+    cli.table(result.mappings || [], {
       columns: [
         { key: 'name', label: 'Mapping' },
         {
           key: 'fields_have_changed',
           label: 'Status',
+          // The truth-table here is asymmetric on purpose: we only render
+          // 'no changes' on an explicit `false` from the backend. Any other
+          // shape (true, missing, drift) falls through to the bare 'changed'
+          // label so we never report a false-negative when the backend
+          // doesn't tell us.
           format: (changed, row) => {
-            if (!changed) return cli.color.green('no changes')
+            if (changed === false) return cli.color.green('no changes')
             if (row.has_unsafe_changes === true) return cli.color.red('changed (unsafe)')
             if (row.has_unsafe_changes === false) return cli.color.yellow('changed (safe)')
             return cli.color.yellow('changed')
@@ -70,8 +85,4 @@ export default class ConnectSchemaDiff extends Command {
     })
     cli.log()
   }
-}
-
-function isValidApiVersion (value) {
-  return /^\d{1,3}\.\d$/.test(value)
 }

--- a/lib/connect/api-version.js
+++ b/lib/connect/api-version.js
@@ -1,0 +1,17 @@
+// Salesforce API versions ship as `NN.0` (e.g. `61.0`). Heroku Connect's
+// supported floor is documented at 32.0; anything below is unsupported and
+// not worth a backend round-trip to find out.
+const SUPPORTED_FLOOR = 32
+
+const VERSION_RE = /^(\d{2,3})\.0$/
+
+export function isValidApiVersion (value) {
+  if (typeof value !== 'string') return false
+  const match = value.match(VERSION_RE)
+  if (!match) return false
+  return Number(match[1]) >= SUPPORTED_FLOOR
+}
+
+export function apiVersionFloor () {
+  return SUPPORTED_FLOOR
+}

--- a/test/commands/connect/schema-diff.js
+++ b/test/commands/connect/schema-diff.js
@@ -73,7 +73,12 @@ describe('connect:schema-diff', () => {
     expect(cli.stdout, 'to contain', 'Account')
     expect(cli.stdout, 'to contain', 'no changes')
     expect(cli.stdout, 'to contain', 'Lead')
-    expect(cli.stdout, 'to contain', 'changed')
+    // The Lead row falls through to the bare 'changed' label because
+    // has_unsafe_changes is missing — assert we did NOT mis-render it as
+    // safe/unsafe/no-changes (the original assertion would have passed
+    // even if status logic was completely broken).
+    expect(cli.stdout, 'not to contain', '(safe)')
+    expect(cli.stdout, 'not to contain', '(unsafe)')
     discoveryApi.done()
     connectionApi.done()
     diffApi.done()
@@ -123,16 +128,37 @@ describe('connect:schema-diff', () => {
     diffApi.done()
   })
 
-  it('rejects an invalid --target-version without making a diff request', async () => {
+  it('rejects an invalid --target-version before any network call', async () => {
+    // Validation runs before withConnection, so neither the discovery nor
+    // the connection-detail nocks should be consumed. Set them up only to
+    // assert they remain pending.
     const discoveryApi = stubDiscovery()
     const connectionApi = stubConnectionDetail()
 
-    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName, '--target-version', 'not-a-version'])
+    let caught
+    try {
+      await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName, '--target-version', 'not-a-version'])
+    } catch (err) {
+      caught = err
+    }
 
-    expect(cli.stderr, 'to contain', 'Invalid --target-version')
-    discoveryApi.done()
-    connectionApi.done()
-    expect(nock.pendingMocks(), 'to be empty')
+    expect(caught, 'to be defined')
+    expect(caught.message, 'to contain', 'Invalid --target-version')
+    expect(nock.pendingMocks(), 'not to be empty')
+    expect(discoveryApi.isDone(), 'to be false')
+    expect(connectionApi.isDone(), 'to be false')
+    nock.cleanAll()
+  })
+
+  it('rejects a sub-floor --target-version even though the regex shape matches', async () => {
+    let caught
+    try {
+      await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName, '--target-version', '1.0'])
+    } catch (err) {
+      caught = err
+    }
+    expect(caught, 'to be defined')
+    expect(caught.message, 'to contain', 'Invalid --target-version')
   })
 
   it('renders unsafe-change styling when has_unsafe_changes is true', async () => {
@@ -152,6 +178,43 @@ describe('connect:schema-diff', () => {
     await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName])
 
     expect(cli.stdout, 'to contain', 'changed (unsafe)')
+    discoveryApi.done()
+    connectionApi.done()
+    diffApi.done()
+  })
+
+  it('renders safe-change styling when has_unsafe_changes is false', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+    const diffApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/api/v3/connections/1234/schema-diff')
+      .reply(200, {
+        guid: '1234',
+        current_api_version: '55.0',
+        target_api_version: '61.0',
+        mappings: [
+          { name: 'Account', result_message: 'length increase', fields_have_changed: true, has_unsafe_changes: false }
+        ]
+      })
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName])
+
+    expect(cli.stdout, 'to contain', 'changed (safe)')
+    discoveryApi.done()
+    connectionApi.done()
+    diffApi.done()
+  })
+
+  it('does not crash when the backend returns no mappings field', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+    const diffApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/api/v3/connections/1234/schema-diff')
+      .reply(200, { guid: '1234', current_api_version: '55.0', target_api_version: '61.0' })
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName])
+
+    expect(cli.stdout, 'to contain', 'Current API Version: 55.0')
     discoveryApi.done()
     connectionApi.done()
     diffApi.done()

--- a/test/commands/connect/schema-diff.js
+++ b/test/commands/connect/schema-diff.js
@@ -1,0 +1,159 @@
+/* globals describe beforeEach afterEach it */
+
+import cli from '@heroku/heroku-cli-util'
+import nock from 'nock'
+import expect from 'unexpected'
+import ConnectSchemaDiff from '../../../commands/connect/schema-diff.js'
+import { runCommand } from '../../run-command.js'
+
+const password = 's3cr3t3'
+const headers = {
+  'content-type': 'application/json',
+  authorization: `Bearer ${password}`,
+  'heroku-client': 'cli'
+}
+
+const appName = 'fake-app'
+const resourceName = 'abcd-ef01'
+
+const connectionDetailUrl = 'https://hc-virginia-qa.herokai.com/connections/1234'
+
+const baseConnection = {
+  id: 1234,
+  name: 'fake-app:fake-conn',
+  region_url: 'https://hc-virginia-qa.herokai.com/',
+  state: 'PAUSED',
+  api_version: '55.0'
+}
+
+function stubDiscovery () {
+  return nock('https://hc-central-qa.herokai.com/', { headers })
+    .get('/connections')
+    .query({ app: appName, resource_name: resourceName })
+    .reply(200, { results: [{ detail_url: connectionDetailUrl }] })
+}
+
+function stubConnectionDetail (extra = {}) {
+  return nock('https://hc-virginia-qa.herokai.com/', { headers })
+    .get('/connections/1234')
+    .query({ deep: true })
+    .reply(200, { ...baseConnection, ...extra })
+}
+
+describe('connect:schema-diff', () => {
+  beforeEach(() => {
+    cli.mockConsole()
+    process.env.HEROKU_API_KEY = password
+  })
+
+  afterEach(() => {
+    delete process.env.HEROKU_API_KEY
+    nock.cleanAll()
+  })
+
+  it('renders a table comparing current and target API versions', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+    const diffApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/api/v3/connections/1234/schema-diff')
+      .reply(200, {
+        guid: '1234',
+        current_api_version: '55.0',
+        target_api_version: '61.0',
+        mappings: [
+          { name: 'Account', result_message: 'Salesforce field definitions have not changed.', fields_have_changed: false },
+          { name: 'Lead', result_message: 'Definitions have changed in Salesforce for field: name.', fields_have_changed: true }
+        ]
+      })
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName])
+
+    expect(cli.stdout, 'to contain', 'Current API Version: 55.0')
+    expect(cli.stdout, 'to contain', 'Target API Version:  61.0')
+    expect(cli.stdout, 'to contain', 'Account')
+    expect(cli.stdout, 'to contain', 'no changes')
+    expect(cli.stdout, 'to contain', 'Lead')
+    expect(cli.stdout, 'to contain', 'changed')
+    discoveryApi.done()
+    connectionApi.done()
+    diffApi.done()
+  })
+
+  it('passes target_version to the API when --target-version is provided', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+    const diffApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/api/v3/connections/1234/schema-diff')
+      .query({ target_version: '60.0' })
+      .reply(200, {
+        guid: '1234',
+        current_api_version: '55.0',
+        target_api_version: '60.0',
+        mappings: []
+      })
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName, '--target-version', '60.0'])
+
+    expect(cli.stdout, 'to contain', 'Target API Version:  60.0')
+    discoveryApi.done()
+    connectionApi.done()
+    diffApi.done()
+  })
+
+  it('outputs JSON when --json is passed', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+    const responseBody = {
+      guid: '1234',
+      current_api_version: '55.0',
+      target_api_version: '61.0',
+      mappings: [
+        { name: 'Account', result_message: 'ok', fields_have_changed: false }
+      ]
+    }
+    const diffApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/api/v3/connections/1234/schema-diff')
+      .reply(200, responseBody)
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName, '--json'])
+
+    expect(JSON.parse(cli.stdout), 'to equal', responseBody)
+    discoveryApi.done()
+    connectionApi.done()
+    diffApi.done()
+  })
+
+  it('rejects an invalid --target-version without making a diff request', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName, '--target-version', 'not-a-version'])
+
+    expect(cli.stderr, 'to contain', 'Invalid --target-version')
+    discoveryApi.done()
+    connectionApi.done()
+    expect(nock.pendingMocks(), 'to be empty')
+  })
+
+  it('renders unsafe-change styling when has_unsafe_changes is true', async () => {
+    const discoveryApi = stubDiscovery()
+    const connectionApi = stubConnectionDetail()
+    const diffApi = nock('https://hc-virginia-qa.herokai.com/', { headers })
+      .get('/api/v3/connections/1234/schema-diff')
+      .reply(200, {
+        guid: '1234',
+        current_api_version: '55.0',
+        target_api_version: '61.0',
+        mappings: [
+          { name: 'Account', result_message: 'unsafe change', fields_have_changed: true, has_unsafe_changes: true }
+        ]
+      })
+
+    await runCommand(ConnectSchemaDiff, ['--app', appName, '--resource', resourceName])
+
+    expect(cli.stdout, 'to contain', 'changed (unsafe)')
+    discoveryApi.done()
+    connectionApi.done()
+    diffApi.done()
+  })
+})


### PR DESCRIPTION
## Summary

Resurrects the `connect:schema-diff` command originally drafted on `ayos-proj-branch` (Aug 2024). Calls the existing `/api/v3/connections/<guid>/schema-diff` endpoint (merged via heroku/herokuconnect#10131) and renders a per-mapping table comparing the connection's current Salesforce API version against a target version.

This is part of a broader push to make Salesforce API version upgrades self-serve — see the design doc in #heroku-edit-sf-api-version-upgrade for context. Salesforce announced API v31.0–40.0 deprecation in Summer '27 and removal in Summer '28.

### Why a fresh branch instead of rebasing `ayos-proj-branch`?

`ayos-proj-branch` was opened before main migrated to ESM + `@oclif/core` Command classes. The 3 original commits are CommonJS + `co` generator style and don't cleanly cherry-pick (conflicts in `lib/connect/api.js` and `index.js` because both files have been completely refactored on main). Rewriting the ~30 lines of business logic in the current pattern was cleaner than fighting the rebase.

The original `ayos-proj-branch` also carried this line in `lib/connect/api.js`:

```js
process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
```

That was a local-dev workaround for self-signed certs and was never safe to ship. Starting fresh meant it never made it onto this branch.

### Decisions captured in the design doc

- **Show all mappings every time** (no `--verbose` flag). Customers should see what's *not* changing too.
- **`has_unsafe_changes`**: the CLI renders `changed (safe)` / `changed (unsafe)` when the backend supplies the field, and falls back to `changed` when it doesn't. The backend currently doesn't surface it — that's tracked as a follow-up.

### Tests

5 new unit tests in `test/commands/connect/schema-diff.js`, all passing locally:

- happy-path table render
- `--target-version` is forwarded to the API
- `--json` round-trips the response body
- invalid `--target-version` is rejected without a network call
- `has_unsafe_changes: true` renders the unsafe styling

All pre-existing tests still pass (24 total).

## Test plan

- [ ] Local: run `heroku connect:schema-diff --app <app>` against a real connection on hc-virginia or similar
- [ ] Verify table rendering matches expected output
- [ ] Verify `--json` output is well-formed
- [ ] Verify `--target-version=invalid` exits cleanly with a helpful error
- [ ] CI passes

## Follow-ups (separate PRs)

- Add `has_unsafe_changes` to the diff endpoint response in `heroku/herokuconnect`
- New `connect:upgrade-api-version` CLI subcommand
- Backend `POST /api/v3/connections/<guid>/upgrade-api-version` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)