### PR TITLE
fix: capitalize descriptions and repair broken README command links

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ DESCRIPTION
   Set database parameters
 ```
 
-_See code: [src/commands/connect/db/set.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/db/set.ts)_
+_See code: [src/commands/connect/db/set.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/db/set.ts)_
 
 ## `heroku connect:diagnose`
 
@@ -88,7 +88,7 @@ DESCRIPTION
   Display diagnostic information about a connection
 ```
 
-_See code: [src/commands/connect/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/diagnose.ts)_
+_See code: [src/commands/connect/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/diagnose.ts)_
 
 ## `heroku connect:export`
 
@@ -109,7 +109,7 @@ DESCRIPTION
   Export configuration from a connection
 ```
 
-_See code: [src/commands/connect/export.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/export.ts)_
+_See code: [src/commands/connect/export.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/export.ts)_
 
 ## `heroku connect:import [FILE]`
 
@@ -133,11 +133,11 @@ DESCRIPTION
   Import configuration from an export file
 ```
 
-_See code: [src/commands/connect/import.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/import.ts)_
+_See code: [src/commands/connect/import.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/import.ts)_
 
 ## `heroku connect:info`
 
-display connection information
+Display connection information
 
 ```
 USAGE
@@ -152,14 +152,14 @@ GLOBAL FLAGS
   --prompt  interactively prompt for command arguments and flags
 
 DESCRIPTION
-  display connection information
+  Display connection information
 ```
 
-_See code: [src/commands/connect/info.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/info.ts)_
+_See code: [src/commands/connect/info.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/info.ts)_
 
 ## `heroku connect:manage-sf-api-version`
 
-compare mapping schemas between API versions and optionally change the version
+Compare mapping schemas between API versions and optionally change the version
 
 ```
 USAGE
@@ -178,7 +178,7 @@ GLOBAL FLAGS
   --prompt  interactively prompt for command arguments and flags
 
 DESCRIPTION
-  compare mapping schemas between API versions and optionally change the version
+  Compare mapping schemas between API versions and optionally change the version
 
   Shows a per-mapping field diff between the connection's current Salesforce API version and a target version. Pass
   --confirm to also change the connection to the target version after displaying the diff. The connection must be paused
@@ -192,7 +192,7 @@ EXAMPLES
   $ heroku connect:manage-sf-api-version --app my-app --resource herokuconnect-swiftly-54348 --target-version 61.0 --json
 ```
 
-_See code: [src/commands/connect/manage-sf-api-version.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/manage-sf-api-version.ts)_
+_See code: [src/commands/connect/manage-sf-api-version.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/manage-sf-api-version.ts)_
 
 ## `heroku connect:mapping:delete [MAPPING]`
 
@@ -217,7 +217,7 @@ DESCRIPTION
   Delete an existing mapping
 ```
 
-_See code: [src/commands/connect/mapping/delete.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/mapping/delete.ts)_
+_See code: [src/commands/connect/mapping/delete.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/delete.ts)_
 
 ## `heroku connect:mapping:diagnose [MAPPING]`
 
@@ -242,7 +242,7 @@ DESCRIPTION
   Display diagnostic information about a mapping
 ```
 
-_See code: [src/commands/connect/mapping/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/mapping/diagnose.ts)_
+_See code: [src/commands/connect/mapping/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/diagnose.ts)_
 
 ## `heroku connect:mapping:reload [MAPPING]`
 
@@ -266,11 +266,11 @@ DESCRIPTION
   Reload a mapping's data from Salesforce
 ```
 
-_See code: [src/commands/connect/mapping/reload.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/mapping/reload.ts)_
+_See code: [src/commands/connect/mapping/reload.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/reload.ts)_
 
 ## `heroku connect:mapping:state [MAPPING]`
 
-return a mapping state
+Return a mapping state
 
 ```
 USAGE
@@ -287,10 +287,10 @@ GLOBAL FLAGS
   --prompt  interactively prompt for command arguments and flags
 
 DESCRIPTION
-  return a mapping state
+  Return a mapping state
 ```
 
-_See code: [src/commands/connect/mapping/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/mapping/state.ts)_
+_See code: [src/commands/connect/mapping/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/state.ts)_
 
 ## `heroku connect:mapping:write-errors NAME`
 
@@ -318,7 +318,7 @@ EXAMPLES
   $ heroku connect:mapping:write-errors -a myapp --resource herokuconnect-twisted-123 Account
 ```
 
-_See code: [src/commands/connect/mapping/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/mapping/write-errors.ts)_
+_See code: [src/commands/connect/mapping/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/write-errors.ts)_
 
 ## `heroku connect:notifications`
 
@@ -343,7 +343,7 @@ DESCRIPTION
   Return the unacknowledged notifications
 ```
 
-_See code: [src/commands/connect/notifications/index.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/notifications/index.ts)_
+_See code: [src/commands/connect/notifications/index.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/notifications/index.ts)_
 
 ## `heroku connect:notifications:acknowledge`
 
@@ -368,7 +368,7 @@ DESCRIPTION
   Acknowledges notifications matching the given criteria
 ```
 
-_See code: [src/commands/connect/notifications/acknowledge.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/notifications/acknowledge.ts)_
+_See code: [src/commands/connect/notifications/acknowledge.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/notifications/acknowledge.ts)_
 
 ## `heroku connect:pause`
 
@@ -389,7 +389,7 @@ DESCRIPTION
   Pause a connection
 ```
 
-_See code: [src/commands/connect/pause.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/pause.ts)_
+_See code: [src/commands/connect/pause.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/pause.ts)_
 
 ## `heroku connect:recover`
 
@@ -413,7 +413,7 @@ ALIASES
   $ heroku connect:restart
 ```
 
-_See code: [src/commands/connect/recover.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/recover.ts)_
+_See code: [src/commands/connect/recover.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/recover.ts)_
 
 ## `heroku connect:restart`
 
@@ -456,7 +456,7 @@ DESCRIPTION
   Resume a connection
 ```
 
-_See code: [src/commands/connect/resume.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/resume.ts)_
+_See code: [src/commands/connect/resume.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/resume.ts)_
 
 ## `heroku connect:sf:auth`
 
@@ -480,11 +480,11 @@ DESCRIPTION
   Authorize access to Salesforce for your connection
 ```
 
-_See code: [src/commands/connect/sf/auth.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/sf/auth.ts)_
+_See code: [src/commands/connect/sf/auth.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/sf/auth.ts)_
 
 ## `heroku connect:state`
 
-return the connection(s) state
+Return the connection(s) state
 
 ```
 USAGE
@@ -499,10 +499,10 @@ GLOBAL FLAGS
   --prompt  interactively prompt for command arguments and flags
 
 DESCRIPTION
-  return the connection(s) state
+  Return the connection(s) state
 ```
 
-_See code: [src/commands/connect/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/state.ts)_
+_See code: [src/commands/connect/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/state.ts)_
 
 ## `heroku connect:write-errors`
 
@@ -527,7 +527,7 @@ EXAMPLES
   $ heroku connect:write-errors -a myapp --resource herokuconnect-twisted-123
 ```
 
-_See code: [src/commands/connect/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.12.3/src/commands/connect/write-errors.ts)_
+_See code: [src/commands/connect/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/write-errors.ts)_
 <!-- commandsstop -->
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ DESCRIPTION
   Set database parameters
 ```
 
-_See code: [src/commands/connect/db/set.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/db/set.ts)_
+_See code: [src/commands/connect/db/set.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/db/set.ts)_
 
 ## `heroku connect:diagnose`
 
@@ -88,7 +88,7 @@ DESCRIPTION
   Display diagnostic information about a connection
 ```
 
-_See code: [src/commands/connect/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/diagnose.ts)_
+_See code: [src/commands/connect/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/diagnose.ts)_
 
 ## `heroku connect:export`
 
@@ -109,7 +109,7 @@ DESCRIPTION
   Export configuration from a connection
 ```
 
-_See code: [src/commands/connect/export.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/export.ts)_
+_See code: [src/commands/connect/export.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/export.ts)_
 
 ## `heroku connect:import [FILE]`
 
@@ -133,7 +133,7 @@ DESCRIPTION
   Import configuration from an export file
 ```
 
-_See code: [src/commands/connect/import.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/import.ts)_
+_See code: [src/commands/connect/import.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/import.ts)_
 
 ## `heroku connect:info`
 
@@ -155,7 +155,7 @@ DESCRIPTION
   Display connection information
 ```
 
-_See code: [src/commands/connect/info.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/info.ts)_
+_See code: [src/commands/connect/info.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/info.ts)_
 
 ## `heroku connect:manage-sf-api-version`
 
@@ -192,7 +192,7 @@ EXAMPLES
   $ heroku connect:manage-sf-api-version --app my-app --resource herokuconnect-swiftly-54348 --target-version 61.0 --json
 ```
 
-_See code: [src/commands/connect/manage-sf-api-version.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/manage-sf-api-version.ts)_
+_See code: [src/commands/connect/manage-sf-api-version.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/manage-sf-api-version.ts)_
 
 ## `heroku connect:mapping:delete [MAPPING]`
 
@@ -217,7 +217,7 @@ DESCRIPTION
   Delete an existing mapping
 ```
 
-_See code: [src/commands/connect/mapping/delete.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/delete.ts)_
+_See code: [src/commands/connect/mapping/delete.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/mapping/delete.ts)_
 
 ## `heroku connect:mapping:diagnose [MAPPING]`
 
@@ -242,7 +242,7 @@ DESCRIPTION
   Display diagnostic information about a mapping
 ```
 
-_See code: [src/commands/connect/mapping/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/diagnose.ts)_
+_See code: [src/commands/connect/mapping/diagnose.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/mapping/diagnose.ts)_
 
 ## `heroku connect:mapping:reload [MAPPING]`
 
@@ -266,7 +266,7 @@ DESCRIPTION
   Reload a mapping's data from Salesforce
 ```
 
-_See code: [src/commands/connect/mapping/reload.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/reload.ts)_
+_See code: [src/commands/connect/mapping/reload.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/mapping/reload.ts)_
 
 ## `heroku connect:mapping:state [MAPPING]`
 
@@ -290,7 +290,7 @@ DESCRIPTION
   Return a mapping state
 ```
 
-_See code: [src/commands/connect/mapping/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/state.ts)_
+_See code: [src/commands/connect/mapping/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/mapping/state.ts)_
 
 ## `heroku connect:mapping:write-errors NAME`
 
@@ -318,7 +318,7 @@ EXAMPLES
   $ heroku connect:mapping:write-errors -a myapp --resource herokuconnect-twisted-123 Account
 ```
 
-_See code: [src/commands/connect/mapping/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/mapping/write-errors.ts)_
+_See code: [src/commands/connect/mapping/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/mapping/write-errors.ts)_
 
 ## `heroku connect:notifications`
 
@@ -343,7 +343,7 @@ DESCRIPTION
   Return the unacknowledged notifications
 ```
 
-_See code: [src/commands/connect/notifications/index.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/notifications/index.ts)_
+_See code: [src/commands/connect/notifications/index.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/notifications/index.ts)_
 
 ## `heroku connect:notifications:acknowledge`
 
@@ -368,7 +368,7 @@ DESCRIPTION
   Acknowledges notifications matching the given criteria
 ```
 
-_See code: [src/commands/connect/notifications/acknowledge.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/notifications/acknowledge.ts)_
+_See code: [src/commands/connect/notifications/acknowledge.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/notifications/acknowledge.ts)_
 
 ## `heroku connect:pause`
 
@@ -389,7 +389,7 @@ DESCRIPTION
   Pause a connection
 ```
 
-_See code: [src/commands/connect/pause.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/pause.ts)_
+_See code: [src/commands/connect/pause.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/pause.ts)_
 
 ## `heroku connect:recover`
 
@@ -413,7 +413,7 @@ ALIASES
   $ heroku connect:restart
 ```
 
-_See code: [src/commands/connect/recover.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/recover.ts)_
+_See code: [src/commands/connect/recover.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/recover.ts)_
 
 ## `heroku connect:restart`
 
@@ -456,7 +456,7 @@ DESCRIPTION
   Resume a connection
 ```
 
-_See code: [src/commands/connect/resume.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/resume.ts)_
+_See code: [src/commands/connect/resume.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/resume.ts)_
 
 ## `heroku connect:sf:auth`
 
@@ -480,7 +480,7 @@ DESCRIPTION
   Authorize access to Salesforce for your connection
 ```
 
-_See code: [src/commands/connect/sf/auth.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/sf/auth.ts)_
+_See code: [src/commands/connect/sf/auth.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/sf/auth.ts)_
 
 ## `heroku connect:state`
 
@@ -502,7 +502,7 @@ DESCRIPTION
   Return the connection(s) state
 ```
 
-_See code: [src/commands/connect/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/state.ts)_
+_See code: [src/commands/connect/state.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/state.ts)_
 
 ## `heroku connect:write-errors`
 
@@ -527,7 +527,7 @@ EXAMPLES
   $ heroku connect:write-errors -a myapp --resource herokuconnect-twisted-123
 ```
 
-_See code: [src/commands/connect/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/v0.13.1/src/commands/connect/write-errors.ts)_
+_See code: [src/commands/connect/write-errors.ts](https://github.com/heroku/heroku-connect-plugin/blob/heroku-connect-plugin-v0.13.1/src/commands/connect/write-errors.ts)_
 <!-- commandsstop -->
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "commands": "./dist/commands",
     "topics": {
       "connect": {
-        "description": "manage connections for Heroku Connect"
+        "description": "Manage connections for Heroku Connect"
       },
       "connect:mapping": {
-        "description": "manage mappings on a Heroku Connect addon"
+        "description": "Manage mappings on a Heroku Connect addon"
       },
       "connect:notifications": {
-        "description": "manage notifications on a Heroku Connect addon"
+        "description": "Manage notifications on a Heroku Connect addon"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "oclif": {
     "bin": "heroku",
     "commands": "./dist/commands",
+    "repositoryPrefix": "<%- repo %>/blob/heroku-connect-plugin-v<%- version %>/<%- commandPath %>",
     "topics": {
       "connect": {
         "description": "Manage connections for Heroku Connect"

--- a/src/commands/connect/info.ts
+++ b/src/commands/connect/info.ts
@@ -6,7 +6,7 @@ import {ConnectContext} from '../../lib/clients/connect.js'
 import * as api from '../../lib/connect/api.js'
 
 export default class ConnectInfo extends Command {
-  static description = 'display connection information'
+  static description = 'Display connection information'
   static flags = {
     app: flags.app({required: true}),
     'check-for-new': flags.boolean({char: 'c', description: 'check for access to any new connections'}),

--- a/src/commands/connect/manage-sf-api-version.ts
+++ b/src/commands/connect/manage-sf-api-version.ts
@@ -31,7 +31,7 @@ function rowRank(row: DiffMapping): number {
 }
 
 export default class ConnectManageSfApiVersion extends Command {
-  static description = `compare mapping schemas between API versions and optionally change the version
+  static description = `Compare mapping schemas between API versions and optionally change the version
 
 Shows a per-mapping field diff between the connection's current Salesforce API version and a target version. \
 Pass --confirm to also change the connection to the target version after displaying the diff. \

--- a/src/commands/connect/mapping/state.ts
+++ b/src/commands/connect/mapping/state.ts
@@ -8,7 +8,7 @@ export default class MappingState extends Command {
   static args = {
     mapping: Args.string({description: 'mapping name'}),
   }
-  static description = 'return a mapping state'
+  static description = 'Return a mapping state'
   static flags = {
     app: flags.app({required: true}),
     resource: flags.string({description: 'specific connection resource name'}),

--- a/src/commands/connect/state.ts
+++ b/src/commands/connect/state.ts
@@ -5,7 +5,7 @@ import {ConnectContext} from '../../lib/clients/connect.js'
 import * as api from '../../lib/connect/api.js'
 
 export default class ConnectState extends Command {
-  static description = 'return the connection(s) state'
+  static description = 'Return the connection(s) state'
   static flags = {
     app: flags.app({required: true}),
     json: flags.boolean({description: 'print output as json'}),


### PR DESCRIPTION
## Summary
Capitalize the command and topic descriptions that began with a lowercase letter (`info`, `state`, `mapping:state`, `manage-sf-api-version`, and the `connect`/`connect:mapping`/`connect:notifications` topics) for consistency, and fix the broken `See code` links in the README — they pointed to `blob/v<version>` but release-please tags releases as `heroku-connect-plugin-v<version>`, so every link 404'd. Overrode `oclif.repositoryPrefix` to build links against the actual tag.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:

**Steps**:
1. Passing CI
2. Local testing
```
h connect --help
Manage connections for Heroku Connect

USAGE
  $ heroku connect:COMMAND

TOPICS
  connect:db             Set database parameters
  connect:mapping        Manage mappings on a Heroku Connect addon
  connect:notifications  Manage notifications on a Heroku Connect addon
  connect:sf             Authorize access to Salesforce for your connection

COMMANDS
  connect:diagnose               Display diagnostic information about a connection
  connect:export                 Export configuration from a connection
  connect:import                 Import configuration from an export file
  connect:info                   Display connection information
  connect:manage-sf-api-version  Compare mapping schemas between API versions and optionally change the version
  connect:notifications          Return the unacknowledged notifications
  connect:pause                  Pause a connection
  connect:recover                Recover a connection
  connect:restart                Recover a connection
  connect:resume                 Resume a connection
  connect:state                  Return the connection(s) state
  connect:write-errors           Display the last 24 hours of write errors on this connection
```

## Screenshots (if applicable)

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [WI number](WI link)
https://salesforce-internal.slack.com/archives/C0912GBBVRR/p1784906706791529?thread_ts=1784650431.973329&cid=C0912GBBVRR
