### PR TITLE
fix: align wrapped Details column in schema diff table

### DIFF
--- a/src/commands/connect/manage-sf-api-version.ts
+++ b/src/commands/connect/manage-sf-api-version.ts
@@ -117,7 +117,7 @@ The connection must be paused before changing the version.`
         },
         header: 'Details',
       },
-    }, {maxWidth: 'none', overflow: 'wrap'})
+    }, {overflow: 'wrap'})
     ux.stdout()
   }
   /* eslint-enable perfectionist/sort-objects */

--- a/test/init.ts
+++ b/test/init.ts
@@ -13,5 +13,5 @@ afterEach(() => nock.cleanAll())
 
 process.env.TZ = 'UTC'
 process.env.CI = process.env.CI || '1'
-process.stdout.columns = 80
-process.stderr.columns = 80
+process.stdout.columns = 120
+process.stderr.columns = 120


### PR DESCRIPTION
## Summary
Fix misaligned wrapping in the schema-diff Details column. `maxWidth: 'none'` disabled wrapping, so long messages overflowed the terminal width and got soft-wrapped at column 0 instead of indented under the Details header. Dropping `maxWidth` bounds the table to the terminal width so `overflow: 'wrap'` wraps within the column. Also bumps the test terminal width 80 → 120 so sample messages don't wrap mid-assertion.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:

**Steps**:
1. Passing CI

## Screenshots (if applicable)
<img width="1512" height="829" alt="Screenshot 2026-07-27 at 11 54 11 AM" src="https://github.com/user-attachments/assets/976b7dd9-300c-486f-ae1d-a7355919db25" />

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [WI number](WI link)
